### PR TITLE
Improve project detail layout and sidebar spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,14 @@
             <h2>Projetos</h2>
             <div id="projectList"></div>
         </aside>
-        <main id="projectDetails"></main>
+        <main id="projectDetails">
+            <div class="project-details">
+                <div class="empty">
+                    <p>Selecione um projeto</p>
+                    <p>Clique em um projeto na lista ao lado para ver os detalhes</p>
+                </div>
+            </div>
+        </main>
     </div>
     <form id="capexForm" novalidate style="display: none;">
             <button type="button" id="backBtn" class="btn" style="display:none;"><span class="material-symbols-outlined">arrow_back</span> Voltar</button>

--- a/script.js
+++ b/script.js
@@ -384,10 +384,20 @@ class SPRestApi {
     }
   }
 
+  function formatDate(dateStr) {
+    if (!dateStr) return '';
+    try {
+      const d = new Date(dateStr);
+      return isNaN(d) ? '' : d.toLocaleDateString('pt-BR');
+    } catch (e) {
+      return '';
+    }
+  }
+
   function showProjectDetails(item) {
     if (!projectDetails) return;
     if (!item) {
-      projectDetails.innerHTML = '<div class="project-details"><div class="empty">Selecione um projeto</div></div>';
+      projectDetails.innerHTML = '<div class="project-details"><div class="empty"><p>Selecione um projeto</p><p>Clique em um projeto na lista ao lado para ver os detalhes</p></div></div>';
       return;
     }
     projectDetails.innerHTML = `
@@ -401,6 +411,18 @@ class SPRestApi {
             <h3>Orçamento</h3>
             <p>${BRL.format(item.CapexBudgetBRL || 0)}</p>
           </div>
+          <div class="detail-card">
+            <h3>Responsável</h3>
+            <p>${item.Responsavel || item.ProjectLeader || ''}</p>
+          </div>
+          <div class="detail-card">
+            <h3>Data de Início</h3>
+            <p>${formatDate(item.DataInicio)}</p>
+          </div>
+          <div class="detail-card">
+            <h3>Data de Conclusão</h3>
+            <p>${formatDate(item.DataFim || item.DataConclusao)}</p>
+          </div>
         </div>
         <div class="detail-desc">
           <h3>Descrição do Projeto</h3>
@@ -408,7 +430,6 @@ class SPRestApi {
         </div>
         <div class="detail-actions">
           <button type="button" class="action-btn edit" id="editProjectDetails">Editar Projeto</button>
-          <button type="button" class="action-btn report">Relatório</button>
           ${item.Status === 'Rascunho' ? '<button type="button" class="action-btn approve">Enviar para Aprovação</button>' : ''}
         </div>
       </div>`;
@@ -450,20 +471,16 @@ class SPRestApi {
         <span class="status-badge" style="background:${getStatusColor(item.Status)}">${item.Status}</span>
         <h3>${item.Title}</h3>
         <p>${BRL.format(item.CapexBudgetBRL || 0)}</p>`;
-      card.addEventListener('click', () => {
-        showProjectDetails(item);
+      card.addEventListener('click', async () => {
+        const fullItem = await projetos.getItemById(item.Id);
+        showProjectDetails(fullItem);
         [...projectList.children].forEach(c => c.classList.remove('selected'));
         card.classList.add('selected');
       });
       projectList.appendChild(card);
     });
     showProjectList();
-    if (items.length) {
-      showProjectDetails(items[0]);
-      projectList.firstChild.classList.add('selected');
-    } else {
-      showProjectDetails(null);
-    }
+    showProjectDetails(null);
   }
 
   function fillForm(item) {

--- a/style.css
+++ b/style.css
@@ -271,6 +271,8 @@
 #static-mirror #app {
   display: flex;
   height: calc(100vh - 80px);
+  padding: 0 20px;
+  box-sizing: border-box;
 }
 
 #static-mirror #projectSidebar {
@@ -309,6 +311,8 @@
 #static-mirror #projectList .project-card h3 {
   margin: 0;
   font-size: 16px;
+  font-weight: 700;
+  color: #000;
 }
 
 #static-mirror #projectList .project-card p {
@@ -324,6 +328,13 @@
   font-size: 11px;
   color: #fff;
   margin-bottom: 6px;
+}
+
+#static-mirror #projectList .status-badge {
+  display: block;
+  width: 100%;
+  padding: 4px 8px;
+  font-weight: 600;
 }
 
 #static-mirror #projectDetails {
@@ -409,11 +420,6 @@
 #static-mirror .project-details .action-btn.edit {
   background: #1e40af;
   color: #fff;
-}
-
-#static-mirror .project-details .action-btn.report {
-  background: #e5e7eb;
-  color: #374151;
 }
 
 #static-mirror .project-details .action-btn.approve {


### PR DESCRIPTION
## Summary
- Add initial hint message for project details and show full info without report button
- Display budget, responsible, start and end dates and description in project details
- Style project list with full-width status badge and sidebar padding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c45441a1a48333b6a19da95f269ead