### PR TITLE
Adjust sidebar width and project action buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -483,30 +483,45 @@ class SPRestApi {
     const actions = document.createElement('div');
     actions.className = 'detail-actions';
 
-    const editBtn = document.createElement('button');
-    editBtn.type = 'button';
-    editBtn.className = 'btn secondary action-btn';
-    editBtn.id = 'editProjectDetails';
-    editBtn.textContent = 'Editar Projeto';
-    actions.appendChild(editBtn);
+    const addActionButton = (label, className, handler) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = className;
+      button.textContent = label;
+      if (typeof handler === 'function') {
+        button.addEventListener('click', handler);
+      }
+      actions.appendChild(button);
+      return button;
+    };
 
-    if (item.Status === 'Rascunho' || item.Status === 'Reprovado para Revisão') {
-      const approveBtn = document.createElement('button');
-      approveBtn.type = 'button';
-      approveBtn.className = 'btn primary action-btn approve';
-      approveBtn.textContent = 'Enviar para Aprovação';
-      actions.appendChild(approveBtn);
+    const status = item.Status || '';
+
+    switch (status) {
+      case 'Rascunho':
+        addActionButton('Editar Projeto', 'btn secondary action-btn', () => editProject(item.Id));
+        addActionButton('Enviar para Aprovação', 'btn primary action-btn approve');
+        break;
+      case 'Reprovado para Revisão':
+        addActionButton('Editar Projeto', 'btn secondary action-btn', () => editProject(item.Id));
+        break;
+      case 'Aprovado':
+      case 'Em Aprovação':
+        addActionButton('Visualizar Projeto', 'btn secondary action-btn', () => editProject(item.Id));
+        break;
+      case 'Reprovado':
+        break;
+      default:
+        addActionButton('Editar Projeto', 'btn secondary action-btn', () => editProject(item.Id));
+        break;
     }
 
-    wrapper.append(header, grid, actions);
+    wrapper.append(header, grid);
+    if (actions.childElementCount > 0) {
+      wrapper.appendChild(actions);
+    }
+
     projectDetails.appendChild(wrapper);
-
-    const isEditable = item.Status !== 'Aprovado';
-    if (isEditable) {
-      editBtn.addEventListener('click', () => editProject(item.Id));
-    } else {
-      editBtn.disabled = true;
-    }
   }
 
   // Botão superior que leva o usuário direto para o formulário de criação

--- a/style.css
+++ b/style.css
@@ -317,7 +317,7 @@
 /* Região flexível que mantém sidebar e painel de detalhes lado a lado */
 #static-mirror #app {
   display: grid;
-  grid-template-columns: minmax(360px, 480px) minmax(0, 1fr);
+  grid-template-columns: minmax(420px, 540px) minmax(0, 1fr);
   gap: 32px;
   padding: 0 40px;
   box-sizing: border-box;
@@ -387,6 +387,9 @@
   font-size: 16px;
   font-weight: 700;
   color: #000;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #static-mirror #projectList .project-card p {


### PR DESCRIPTION
## Summary
- widen the sidebar and keep project titles on a single line for better readability
- tailor the project details action buttons to show only the allowed actions for each status

## Testing
- not run (static files only)

------
https://chatgpt.com/codex/tasks/task_e_68c9a69e2db48333ac6de9009217bb70