### PR TITLE
Handle SharePoint Id property when saving project structure

### DIFF
--- a/script.js
+++ b/script.js
@@ -1313,7 +1313,12 @@ class SPRestApi {
         kpiExpected: payload.projeto.kpi_esperado
       });
 
-      await saveProjectStructure(infoProjeto.d.ID, payload.milestones);
+      const projectId = Number(infoProjeto?.d?.Id ?? infoProjeto?.d?.ID);
+      if (!Number.isFinite(projectId)) {
+        throw new Error('Project ID inválido retornado pelo SharePoint.');
+      }
+
+      await saveProjectStructure(projectId, payload.milestones);
       updateStatus('Formulário enviado com sucesso!', 'success');
       refreshGantt();
       await loadUserProjects();


### PR DESCRIPTION
## Summary
- read the SharePoint project identifier using the available `Id`/`ID` property
- validate the resolved identifier and pass it to `saveProjectStructure`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca02e0009c83338c46f7708c3894d8