### PR TITLE
Remove unused milestone activity fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,37 +341,6 @@
                     <label>Término da Atividade</label>
                     <input type="date" class="act-end" required />
                 </div>
-                <div class="activity-field activity-field-pep col-2">
-                    <label>Elemento PEP da Atividade</label>
-                    <select name="kpi" required>
-                        <option value="">Selecione…</option>
-                        <option>DESP.ENGENHARIA / DETALHAMENTO PROJETO</option>
-                        <option>AQUISIÇÃO DE EQUIPAMENTOS NACIONAIS</option>
-                        <option>AQUISIÇÃO DE EQUIPAMENTOS IMPORTADOS</option>
-                        <option>AQUISIÇÃO DE VEÍCULOS</option>
-                        <option>DESPESAS COM OBRAS CIVIS</option>
-                        <option>DESP.MONTAGEM EQUIPTOS/ESTRUTURAS/OUTRAS</option>
-                        <option>AQ.DE COMPONENTES/MAT.INSTAL./FERRAMENTA</option>
-                        <option>DESPESAS COM MEIO AMBIENTE</option>
-                        <option>DESPESAS COM SEGURANÇA</option>
-                        <option>DESPESAS COM SEGUROS</option>
-                        <option>DESP.CONSULTORIA INTERNA (AMS)-TEC.INFOR</option>
-                        <option>DESP.CONSULTORIA EXTERNA - TEC.INFOR</option>
-                        <option>AQUISIÇÃO DE HARDWARE (NOTEBOOKS, ETC)</option>
-                        <option>DESP.GERENCIAMENTO E COORDENAÇÃO</option>
-                        <option>AQUISIÇÃO DE SOFTWARE</option>
-                        <option>CONTINGÊNCIAS</option>
-                    </select>
-                </div>
-
-                <div class="activity-field activity-field-supplier col-3">
-                    <label>Fornecedor da Atividade</label>
-                    <input type="text" class="act-supplier" required maxlength="160" placeholder="Informe o fornecedor responsável" />
-                </div>
-                <div class="activity-field activity-field-supplier-notes col-3">
-                    <label>Descrição do Fornecedor</label>
-                    <textarea class="act-supplier-notes" maxlength="600" placeholder="Detalhe condições comerciais, escopo contratado ou observações relevantes."></textarea>
-                </div>
                 <div class="activity-field activity-field-overview col-6">
 
                     <label>Descrição Geral da Atividade</label>

--- a/script.js
+++ b/script.js
@@ -1222,7 +1222,6 @@ class SPRestApi {
         const start = a.querySelector('.act-start');
         const end = a.querySelector('.act-end');
         const overviewEl = a.querySelector('.act-overview');
-        const supplierEl = a.querySelector('.act-supplier');
         const yearRows = [...a.querySelectorAll('.row[data-year]')];
 
         if (!title.value.trim()) errs.push(`Atividade ${jdx} do marco ${idx}: informe o <strong>título</strong>.`);
@@ -1236,10 +1235,6 @@ class SPRestApi {
             errs.push(`Atividade ${jdx} do marco ${idx}: informe a <strong>descrição da atividade</strong>.`);
             errsEl.push(overviewEl);
           }
-        }
-        if (!supplierEl || !supplierEl.value.trim()) {
-          errs.push(`Atividade ${jdx} do marco ${idx}: informe o <strong>fornecedor da atividade</strong>.`);
-          if (supplierEl) errsEl.push(supplierEl);
         }
         if (yearRows.length === 0) {
           errs.push(`Atividade ${jdx} do marco ${idx}: defina <strong>datas de início e fim</strong> válidas para gerar campos anuais.`);

--- a/style.css
+++ b/style.css
@@ -654,6 +654,17 @@
   align-items: start;
 }
 
+#static-mirror .activity-field-title,
+#static-mirror .activity-field-years,
+#static-mirror .activity-field-overview {
+  grid-column: span 6;
+}
+
+#static-mirror .activity-field-start,
+#static-mirror .activity-field-end {
+  grid-column: span 3;
+}
+
 #static-mirror .activity-field {
   display: flex;
   flex-direction: column;
@@ -712,15 +723,12 @@
 
   #static-mirror .activity-field-title,
   #static-mirror .activity-field-years,
-  #static-mirror .activity-field-overview,
-  #static-mirror .activity-field-supplier,
-  #static-mirror .activity-field-supplier-notes {
+  #static-mirror .activity-field-overview {
     grid-column: span 3;
   }
 
   #static-mirror .activity-field-start,
-  #static-mirror .activity-field-end,
-  #static-mirror .activity-field-pep {
+  #static-mirror .activity-field-end {
     grid-column: span 3;
   }
 
@@ -742,8 +750,6 @@
   #static-mirror .activity-field-title,
   #static-mirror .activity-field-start,
   #static-mirror .activity-field-end,
-  #static-mirror .activity-field-pep,
-  #static-mirror .activity-field-supplier,
   #static-mirror .activity-field-overview,
   #static-mirror .activity-field-years {
     grid-column: 1 / -1;
@@ -802,12 +808,6 @@
 #static-mirror .activity-capex .act-year .c-4,
 #static-mirror .activity-capex .act-year .c-8 {
   grid-column: 1 / -1;
-}
-
-#static-mirror .activity-supplier .supplier-description {
-  margin-top: 2px;
-  font-size: 13px;
-  line-height: 1.5;
 }
 
 #static-mirror .activity-actions {


### PR DESCRIPTION
## Summary
- remove the milestone activity inputs that were not persisted to SharePoint
- simplify milestone validation now that supplier data is no longer collected
- clean up the activity grid styles to reflect the slimmer layout

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68ca2d27306c83338382d8f188e8d8ac