### PR TITLE
Restyle dashboard to match simplified overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,6 +231,10 @@
         <legend>9. KEY Projects</legend>
         <p class="hint">Disponível quando o orçamento é igual ou superior a R$ 1.000.000,00.</p>
         <div id="milestoneList" class="dynamic-list"></div>
+        <div id="ganttContainer" class="gantt-container hidden" aria-live="polite">
+          <h3 id="ganttChartTitle">Cronograma do Projeto</h3>
+          <div id="ganttChart" class="gantt-chart" role="img" aria-label="Gráfico de Gantt do projeto"></div>
+        </div>
         <button type="button" id="addMilestoneBtn" class="btn ghost">Adicionar Marco</button>
       </fieldset>
 
@@ -329,6 +333,7 @@
     </div>
   </template>
 
+  <script src="https://www.gstatic.com/charts/loader.js"></script>
   <script src="script.js" type="module"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -153,6 +153,10 @@ const keyProjectSection = document.getElementById('keyProjectSection');
 const milestoneList = document.getElementById('milestoneList');
 const addMilestoneBtn = document.getElementById('addMilestoneBtn');
 
+const ganttContainer = document.getElementById('ganttContainer');
+const ganttTitleEl = document.getElementById('ganttChartTitle');
+const ganttChartEl = document.getElementById('ganttChart');
+
 const approvalYearInput = document.getElementById('approvalYear');
 const projectBudgetInput = document.getElementById('projectBudget');
 
@@ -160,6 +164,205 @@ const simplePepTemplate = document.getElementById('simplePepTemplate');
 const milestoneTemplate = document.getElementById('milestoneTemplate');
 const activityTemplate = document.getElementById('activityTemplate');
 const activityPepTemplate = document.getElementById('activityPepTemplate');
+
+// ============================================================================
+// Gantt Chart
+// ============================================================================
+let ganttLoaderStarted = false;
+let ganttReady = false;
+let ganttRefreshScheduled = false;
+
+function initGantt() {
+  if (ganttLoaderStarted) return;
+  if (!window.google || !google.charts) return;
+  ganttLoaderStarted = true;
+  google.charts.load('current', { packages: ['gantt'] });
+  google.charts.setOnLoadCallback(() => {
+    ganttReady = true;
+    refreshGantt();
+  });
+}
+
+function queueGanttRefresh() {
+  if (ganttRefreshScheduled) return;
+  ganttRefreshScheduled = true;
+  requestAnimationFrame(() => {
+    ganttRefreshScheduled = false;
+    refreshGantt();
+  });
+}
+
+function refreshGantt() {
+  if (!ganttContainer) return;
+  if (keyProjectSection.classList.contains('hidden')) {
+    ganttContainer.classList.add('hidden');
+    if (ganttChartEl) {
+      ganttChartEl.innerHTML = '';
+    }
+    return;
+  }
+
+  const milestones = collectMilestonesForGantt();
+  const draw = () => drawGantt(milestones);
+
+  if (ganttReady && window.google?.visualization?.Gantt) {
+    draw();
+  } else if (ganttLoaderStarted && window.google?.charts) {
+    google.charts.setOnLoadCallback(draw);
+  } else {
+    initGantt();
+  }
+}
+
+function collectMilestonesForGantt() {
+  const milestones = [];
+  if (!milestoneList) return milestones;
+
+  milestoneList.querySelectorAll('.milestone').forEach((milestoneEl, index) => {
+    const titleInput = milestoneEl.querySelector('.milestone-title');
+    const nome = titleInput?.value.trim() || `Marco ${index + 1}`;
+    const atividades = [];
+
+    milestoneEl.querySelectorAll('.activity').forEach((activityEl, actIndex) => {
+      const title = activityEl.querySelector('.activity-title')?.value.trim() || `Atividade ${actIndex + 1}`;
+      const inicio = activityEl.querySelector('.activity-start')?.value || null;
+      const fim = activityEl.querySelector('.activity-end')?.value || null;
+      const anual = [];
+
+      activityEl.querySelectorAll('.activity-pep').forEach((pepEl) => {
+        const ano = parseNumber(pepEl.querySelector('.activity-pep-year')?.value);
+        const amountRaw = parseFloat(pepEl.querySelector('.activity-pep-amount')?.value);
+        const amount = Number.isFinite(amountRaw) ? amountRaw : 0;
+        const descricao = pepEl.querySelector('.activity-pep-title')?.value.trim() || '';
+
+        if (!descricao && !ano && amount === 0) {
+          return;
+        }
+
+        anual.push({
+          ano,
+          capex_brl: amount,
+          descricao
+        });
+      });
+
+      atividades.push({
+        titulo: title,
+        inicio,
+        fim,
+        anual
+      });
+    });
+
+    milestones.push({
+      nome,
+      atividades
+    });
+  });
+
+  return milestones;
+}
+
+function drawGantt(milestones) {
+  if (!ganttContainer || !ganttChartEl || !window.google?.visualization) return;
+
+  const data = new google.visualization.DataTable();
+  data.addColumn('string', 'Task ID');
+  data.addColumn('string', 'Task Name');
+  data.addColumn('string', 'Resource');
+  data.addColumn('date', 'Start Date');
+  data.addColumn('date', 'End Date');
+  data.addColumn('number', 'Duration');
+  data.addColumn('number', 'Percent Complete');
+  data.addColumn('string', 'Dependencies');
+  data.addColumn({ type: 'string', role: 'tooltip', p: { html: true } });
+
+  const rows = [];
+  let idCounter = 0;
+
+  milestones.forEach((milestone) => {
+    if (!milestone) return;
+    idCounter += 1;
+    let msStart = null;
+    let msEnd = null;
+    const activityRows = [];
+    const activities = Array.isArray(milestone.atividades) ? milestone.atividades : [];
+
+    activities.forEach((activity, index) => {
+      const startDate = activity.inicio ? new Date(activity.inicio) : new Date();
+      const endDate = activity.fim ? new Date(activity.fim) : new Date(startDate.getTime() + 1000 * 60 * 60 * 24);
+      if (!msStart || startDate < msStart) msStart = startDate;
+      if (!msEnd || endDate > msEnd) msEnd = endDate;
+
+      const totalCapex = activity.anual.reduce((total, year) => total + (year.capex_brl || 0), 0);
+      const tooltipLines = activity.anual.map((year) => {
+        const yearLabel = year.ano ?? 'Ano não informado';
+        const description = year.descricao ? ` - ${year.descricao}` : '';
+        return `${yearLabel}: ${BRL.format(year.capex_brl || 0)}${description}`;
+      });
+
+      activityRows.push([
+        `ms-${idCounter}-${index}`,
+        activity.titulo || `Atividade ${index + 1}`,
+        'Atividade',
+        startDate,
+        endDate,
+        null,
+        0,
+        `ms-${idCounter}`,
+        `CAPEX total: ${BRL.format(totalCapex)}${tooltipLines.length ? `<br/>${tooltipLines.join('<br/>')}` : ''}`
+      ]);
+    });
+
+    if (msStart && msEnd) {
+      rows.push([
+        `ms-${idCounter}`,
+        milestone.nome,
+        'milestone',
+        msStart,
+        msEnd,
+        null,
+        0,
+        null,
+        milestone.nome
+      ]);
+    }
+
+    rows.push(...activityRows);
+  });
+
+  if (!rows.length) {
+    ganttChartEl.innerHTML = '';
+    ganttContainer.classList.add('hidden');
+    return;
+  }
+
+  ganttContainer.classList.remove('hidden');
+  if (ganttTitleEl) {
+    ganttTitleEl.classList.remove('hidden');
+  }
+
+  data.addRows(rows);
+  const chart = new google.visualization.Gantt(ganttChartEl);
+  chart.draw(data, {
+    height: Math.max(200, rows.length * 40 + 40),
+    tooltip: { isHtml: true },
+    gantt: {
+      criticalPathEnabled: false,
+      arrow: {
+        angle: 0,
+        width: 0,
+        color: '#ffffff',
+        radius: 0
+      },
+      trackHeight: 30,
+      palette: [
+        { color: '#460a78', dark: '#be2846', light: '#e63c41' },
+        { color: '#f58746', dark: '#e63c41', light: '#ffbe6e' }
+      ]
+    }
+  });
+}
 
 // ============================================================================
 // Inicialização
@@ -170,12 +373,16 @@ function init() {
   approvalYearInput.value = currentYear;
   approvalYearInput.max = currentYear;
   loadProjects();
+  initGantt();
+  window.addEventListener('load', initGantt, { once: true });
 }
 
 function bindEvents() {
   newProjectBtn.addEventListener('click', () => openProjectForm('create'));
   closeFormBtn.addEventListener('click', closeForm);
-  projectSearch.addEventListener('input', () => renderProjectList());
+  if (projectSearch) {
+    projectSearch.addEventListener('input', () => renderProjectList());
+  }
 
   projectForm.addEventListener('submit', handleFormSubmit);
   sendApprovalBtn.addEventListener('click', () => {
@@ -202,28 +409,37 @@ function bindEvents() {
   });
 
   milestoneList.addEventListener('click', (event) => {
-    if (event.target.classList.contains('remove-milestone')) {
-      event.target.closest('.milestone')?.remove();
+    const { target } = event;
+    if (target.classList.contains('remove-milestone')) {
+      target.closest('.milestone')?.remove();
+      queueGanttRefresh();
       return;
     }
-    if (event.target.classList.contains('add-activity')) {
-      const milestone = event.target.closest('.milestone');
+    if (target.classList.contains('add-activity')) {
+      const milestone = target.closest('.milestone');
       addActivityBlock(milestone);
+      queueGanttRefresh();
       return;
     }
-    if (event.target.classList.contains('remove-activity')) {
-      event.target.closest('.activity')?.remove();
+    if (target.classList.contains('remove-activity')) {
+      target.closest('.activity')?.remove();
+      queueGanttRefresh();
       return;
     }
-    if (event.target.classList.contains('add-activity-pep')) {
-      const activity = event.target.closest('.activity');
+    if (target.classList.contains('add-activity-pep')) {
+      const activity = target.closest('.activity');
       addActivityPepRow(activity);
+      queueGanttRefresh();
       return;
     }
-    if (event.target.classList.contains('remove-activity-pep')) {
-      event.target.closest('.activity-pep')?.remove();
+    if (target.classList.contains('remove-activity-pep')) {
+      target.closest('.activity-pep')?.remove();
+      queueGanttRefresh();
     }
   });
+
+  milestoneList.addEventListener('input', queueGanttRefresh);
+  milestoneList.addEventListener('change', queueGanttRefresh);
 }
 
 // ============================================================================
@@ -240,7 +456,7 @@ async function loadProjects() {
 }
 
 function renderProjectList() {
-  const filter = projectSearch.value.toLowerCase();
+  const filter = (projectSearch?.value || '').toLowerCase();
   projectList.innerHTML = '';
 
   const filtered = state.projects.filter((item) =>
@@ -263,19 +479,42 @@ function renderProjectList() {
     }
     card.dataset.id = item.Id;
 
-    const title = document.createElement('h3');
+    const accent = document.createElement('span');
+    accent.className = 'project-card-accent';
+    accent.style.background = statusColor(item.status);
+
+    const content = document.createElement('div');
+    content.className = 'project-card-content';
+
+    const title = document.createElement('span');
+    title.className = 'project-card-title';
     title.textContent = item.Title || 'Projeto sem título';
 
+    const bottom = document.createElement('div');
+    bottom.className = 'project-card-bottom';
+
     const status = document.createElement('span');
-    status.className = 'status';
-    status.style.background = statusColor(item.status);
+    status.className = 'project-card-status';
     status.textContent = item.status || 'Sem status';
+    status.style.color = statusColor(item.status);
+    bottom.append(status);
 
-    const info = document.createElement('p');
-    const budget = item.budgetBrl ? ` • ${BRL.format(item.budgetBrl)}` : '';
-    info.textContent = `${item.approvalYear || ''}${budget}`.trim();
+    const metaPieces = [];
+    if (item.approvalYear) {
+      metaPieces.push(item.approvalYear);
+    }
+    if (item.budgetBrl) {
+      metaPieces.push(BRL.format(item.budgetBrl));
+    }
+    if (metaPieces.length) {
+      const meta = document.createElement('span');
+      meta.className = 'project-card-meta';
+      meta.textContent = metaPieces.join(' • ');
+      bottom.append(meta);
+    }
 
-    card.append(title, status, info);
+    content.append(title, bottom);
+    card.append(accent, content);
     card.addEventListener('click', () => selectProject(item.Id));
     projectList.append(card);
   });
@@ -330,89 +569,113 @@ function renderProjectDetails(detail) {
     return;
   }
 
-  const { project, milestones, activities, simplePeps, activityPeps } = detail;
+  const { project } = detail;
+
   if (project.status === 'Reprovado') {
+    const message = document.createElement('div');
+    message.className = 'empty-state';
+    const title = document.createElement('h2');
+    title.textContent = project.Title || 'Projeto reprovado';
+    const text = document.createElement('p');
+    text.textContent = 'Este projeto foi reprovado e está disponível apenas para consulta.';
+    message.append(title, text);
+    projectDetails.append(message);
     return;
   }
 
   const wrapper = document.createElement('div');
+  wrapper.className = 'project-overview';
 
   const header = document.createElement('div');
-  header.className = 'details-header';
+  header.className = 'project-overview__header';
   const title = document.createElement('h2');
+  title.className = 'project-overview__title';
   title.textContent = project.Title || 'Projeto sem título';
   const status = document.createElement('span');
-  status.className = 'status';
+  status.className = 'status-pill';
   status.style.background = statusColor(project.status);
   status.textContent = project.status || 'Sem status';
   header.append(title, status);
 
-  if (['Rascunho', 'Reprovado para Revisão'].includes(project.status)) {
-    const editBtn = document.createElement('button');
-    editBtn.type = 'button';
-    editBtn.className = 'btn primary';
-    editBtn.textContent = 'Editar Projeto';
-    editBtn.addEventListener('click', () => openProjectForm('edit', detail));
-    header.append(editBtn);
-  } else if (project.status === 'Aprovado') {
+  if (project.status === 'Aprovado') {
     const info = document.createElement('p');
-    info.className = 'hint';
+    info.className = 'project-overview__hint';
     info.textContent = 'Projeto aprovado - somente leitura.';
     header.append(info);
   }
 
   wrapper.append(header);
 
-  const overview = document.createElement('div');
-  overview.className = 'details-grid';
-
-  overview.append(
-    createDetailBox('Ano de Aprovação', project.approvalYear),
-    createDetailBox('Orçamento (R$)', project.budgetBrl ? BRL.format(project.budgetBrl) : ''),
-    createDetailBox('Nível de Investimento', project.investmentLevel),
-    createDetailBox('Origem da Verba', project.fundingSource)
+  const highlightGrid = document.createElement('div');
+  highlightGrid.className = 'project-overview__grid';
+  highlightGrid.append(
+    createHighlightBox('Orçamento', project.budgetBrl ? BRL.format(project.budgetBrl) : '—', { variant: 'budget' }),
+    createHighlightBox('Responsável', project.projectLeader || project.projectUser || 'Não informado')
   );
+  wrapper.append(highlightGrid);
 
-  overview.append(
-    createDetailBox('Empresa', project.company),
-    createDetailBox('Centro', project.center),
-    createDetailBox('Unidade', project.unit),
-    createDetailBox('Local de Implantação', project.location)
+  const timelineGrid = document.createElement('div');
+  timelineGrid.className = 'project-overview__grid';
+  timelineGrid.append(
+    createHighlightBox('Data de Início', formatDateValue(project.startDate)),
+    createHighlightBox('Data de Conclusão', formatDateValue(project.endDate))
   );
+  wrapper.append(timelineGrid);
 
-  overview.append(
-    createDetailBox('Project User', project.projectUser),
-    createDetailBox('Coordenador do Projeto', project.projectLeader),
-    createDetailBox('Período', formatPeriod(project.startDate, project.endDate))
-  );
+  const descriptionSection = document.createElement('section');
+  descriptionSection.className = 'project-description';
+  const descTitle = document.createElement('h3');
+  descTitle.textContent = 'Descrição do Projeto';
+  const descText = document.createElement('p');
+  descText.className = 'project-description__text';
+  descText.textContent = project.proposedSolution || project.businessNeed || 'Sem descrição informada.';
+  descriptionSection.append(descTitle, descText);
+  wrapper.append(descriptionSection);
 
-  wrapper.append(overview);
+  const actions = document.createElement('div');
+  actions.className = 'project-overview__actions';
 
-  wrapper.append(createTextSection('Sumário do Projeto', project.businessNeed));
-  wrapper.append(createTextSection('Comentário', project.proposedSolution));
+  const canEdit = ['Rascunho', 'Reprovado para Revisão'].includes(project.status);
+  const canSendApproval = ['Rascunho', 'Reprovado para Revisão'].includes(project.status);
+  const canReject = project.status === 'Em Aprovação';
 
-  const kpiSection = document.createElement('div');
-  kpiSection.className = 'detail-box';
-  const kpiTitle = document.createElement('h4');
-  kpiTitle.textContent = 'Indicadores de Desempenho';
-  const kpiContent = document.createElement('p');
-  const pieces = [
-    project.kpiType ? `Tipo: ${project.kpiType}` : '',
-    project.kpiName ? `Nome: ${project.kpiName}` : '',
-    project.kpiDescription ? `Descrição: ${project.kpiDescription}` : '',
-    project.kpiCurrent !== null && project.kpiCurrent !== undefined ? `Atual: ${project.kpiCurrent}` : '',
-    project.kpiExpected !== null && project.kpiExpected !== undefined ? `Esperado: ${project.kpiExpected}` : ''
-  ].filter(Boolean);
-  kpiContent.innerHTML = pieces.join('<br>') || 'Sem indicadores informados.';
-  kpiSection.append(kpiTitle, kpiContent);
-  wrapper.append(kpiSection);
-
-  if (project.budgetBrl < BUDGET_THRESHOLD && simplePeps.length) {
-    wrapper.append(createPepSection(simplePeps));
+  if (canEdit) {
+    const editBtn = document.createElement('button');
+    editBtn.type = 'button';
+    editBtn.className = 'btn primary';
+    editBtn.textContent = 'Editar Projeto';
+    editBtn.addEventListener('click', () => openProjectForm('edit', detail));
+    actions.append(editBtn);
   }
 
-  if (project.budgetBrl >= BUDGET_THRESHOLD && milestones.length) {
-    wrapper.append(createKeyProjectsSection(milestones, activities, activityPeps));
+  if (canReject) {
+    const rejectBtn = document.createElement('button');
+    rejectBtn.type = 'button';
+    rejectBtn.className = 'btn ghost';
+    rejectBtn.textContent = 'Recusar';
+    rejectBtn.addEventListener('click', () => {
+      openProjectForm('edit', detail);
+      statusField.value = 'Reprovado para Revisão';
+    });
+    actions.append(rejectBtn);
+  }
+
+  if (canSendApproval) {
+    const approveBtn = document.createElement('button');
+    approveBtn.type = 'button';
+    approveBtn.className = 'btn accent';
+    approveBtn.textContent = 'Enviar para Aprovação';
+    approveBtn.addEventListener('click', () => {
+      openProjectForm('edit', detail);
+      requestAnimationFrame(() => {
+        sendApprovalBtn?.focus();
+      });
+    });
+    actions.append(approveBtn);
+  }
+
+  if (actions.childElementCount) {
+    wrapper.append(actions);
   }
 
   projectDetails.append(wrapper);
@@ -429,102 +692,40 @@ function createEmptyState() {
   return empty;
 }
 
-function createDetailBox(label, value) {
+function createHighlightBox(label, value, options = {}) {
+  const { variant } = options;
   const box = document.createElement('div');
-  box.className = 'detail-box';
-  const title = document.createElement('h4');
-  title.textContent = label;
-  const text = document.createElement('p');
-  text.textContent = value || '—';
-  box.append(title, text);
+  box.className = 'project-highlight';
+  if (variant) {
+    box.classList.add(`project-highlight--${variant}`);
+  }
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'project-highlight__label';
+  labelEl.textContent = label;
+
+  const valueEl = document.createElement('span');
+  valueEl.className = 'project-highlight__value';
+  valueEl.textContent = value || '—';
+  if (variant === 'budget') {
+    valueEl.classList.add('project-highlight__value--budget');
+  }
+
+  box.append(labelEl, valueEl);
   return box;
 }
 
-function createTextSection(label, content) {
-  const container = document.createElement('section');
-  const title = document.createElement('h3');
-  title.className = 'section-title';
-  title.textContent = label;
-  const box = document.createElement('div');
-  box.className = 'detail-box';
-  const text = document.createElement('p');
-  text.textContent = content || 'Sem informações.';
-  box.append(text);
-  container.append(title, box);
-  return container;
-}
+function formatDateValue(value) {
+  if (!value) {
+    return '—';
+  }
 
-function createPepSection(peps) {
-  const container = document.createElement('section');
-  const title = document.createElement('h3');
-  title.className = 'section-title';
-  title.textContent = 'PEPs do Projeto';
-  const list = document.createElement('div');
-  list.className = 'inline-list';
-  peps.forEach((pep) => {
-    const article = document.createElement('article');
-    const heading = document.createElement('h4');
-    heading.textContent = pep.Title || 'Elemento PEP';
-    const text = document.createElement('p');
-    const amount = pep.amountBrl ? BRL.format(pep.amountBrl) : '—';
-    text.textContent = `Valor: ${amount} • Ano: ${pep.year || '—'}`;
-    article.append(heading, text);
-    list.append(article);
-  });
-  container.append(title, list);
-  return container;
-}
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
 
-function createKeyProjectsSection(milestones, activities, activityPeps) {
-  const container = document.createElement('section');
-  const title = document.createElement('h3');
-  title.className = 'section-title';
-  title.textContent = 'Key Projects';
-  container.append(title);
-
-  const list = document.createElement('div');
-  list.className = 'inline-list';
-
-  milestones.forEach((milestone) => {
-    const article = document.createElement('article');
-    const heading = document.createElement('h4');
-    heading.textContent = milestone.Title || 'Marco';
-    article.append(heading);
-
-    const milestoneActivities = activities.filter((act) => act.milestonesId === milestone.Id);
-    milestoneActivities.forEach((activity) => {
-      const activityBox = document.createElement('div');
-      activityBox.className = 'detail-box';
-      const activityTitle = document.createElement('strong');
-      activityTitle.textContent = activity.Title || 'Atividade';
-      const description = document.createElement('div');
-      description.innerHTML = [
-        formatPeriod(activity.startDate, activity.endDate),
-        activity.supplier ? `Fornecedor: ${activity.supplier}` : '',
-        activity.activityDescription || ''
-      ].filter(Boolean).join('<br>');
-
-      const pepsForActivity = activityPeps.filter((pep) => pep.activitiesId === activity.Id);
-      if (pepsForActivity.length) {
-        const pepList = document.createElement('ul');
-        pepsForActivity.forEach((pep) => {
-          const li = document.createElement('li');
-          const amount = pep.amountBrl ? BRL.format(pep.amountBrl) : '—';
-          li.textContent = `${pep.Title || 'PEP'} • ${amount} • Ano ${pep.year || '—'}`;
-          pepList.append(li);
-        });
-        description.appendChild(pepList);
-      }
-
-      activityBox.append(activityTitle, description);
-      article.append(activityBox);
-    });
-
-    list.append(article);
-  });
-
-  container.append(list);
-  return container;
+  return DATE_FMT.format(date);
 }
 
 // ============================================================================
@@ -560,6 +761,7 @@ function openProjectForm(mode, detail = null) {
 
   updateSimplePepYears();
   overlay.classList.remove('hidden');
+  queueGanttRefresh();
 }
 
 function fillFormWithProject(detail) {
@@ -658,6 +860,8 @@ function fillFormWithProject(detail) {
       ensureMilestoneBlock();
     }
   }
+
+  queueGanttRefresh();
 }
 
 function closeForm() {
@@ -705,6 +909,8 @@ function updateBudgetSections(options = {}) {
       ensureSimplePepRow();
     }
   }
+
+  queueGanttRefresh();
 }
 
 function setSectionInteractive(section, enabled) {
@@ -731,6 +937,7 @@ function ensureMilestoneBlock() {
   const block = createMilestoneBlock();
   milestoneList.append(block);
   addActivityBlock(block, {}, true);
+  queueGanttRefresh();
 }
 
 function createSimplePepRow({ id = '', title = '', amount = '', year = '' } = {}) {
@@ -765,6 +972,7 @@ function addActivityBlock(milestoneElement, data = {}, addDefaultPep = true) {
   if (addDefaultPep) {
     addActivityPepRow(activity);
   }
+  queueGanttRefresh();
   return activity;
 }
 
@@ -783,6 +991,7 @@ function addActivityPepRow(activityElement, data = {}) {
   const list = activityElement.querySelector('.activity-pep-list');
   const row = createActivityPepRow(data);
   list.append(row);
+  queueGanttRefresh();
   return row;
 }
 
@@ -1011,13 +1220,6 @@ function showStatus(message, success = false) {
 function showError(message) {
   formErrors.textContent = message;
   formErrors.classList.add('show');
-}
-
-function formatPeriod(start, end) {
-  if (!start && !end) return 'Sem datas definidas';
-  const startLabel = start ? DATE_FMT.format(new Date(start)) : '—';
-  const endLabel = end ? DATE_FMT.format(new Date(end)) : '—';
-  return `${startLabel} até ${endLabel}`;
 }
 
 function statusColor(status) {

--- a/style.css
+++ b/style.css
@@ -119,27 +119,30 @@ p {
 .sidebar {
   background: var(--card);
   border-radius: 18px;
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
-  padding: 24px;
+  border: 1px solid rgba(70, 10, 120, 0.08);
+  box-shadow: 0 18px 44px rgba(40, 24, 68, 0.12);
+  padding: 24px 20px;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 20px;
   height: calc(100vh - 160px);
   position: sticky;
   top: 120px;
 }
 
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .sidebar-header h2 {
-  margin-bottom: 12px;
+  margin: 0;
+  font-size: 20px;
 }
 
 .sidebar-header input {
-  width: 100%;
-  padding: 10px 12px;
-  border-radius: 8px;
-  border: 1px solid var(--border);
-  font-size: 14px;
+  display: none;
 }
 
 .project-list {
@@ -147,46 +150,96 @@ p {
   flex-direction: column;
   gap: 12px;
   overflow-y: auto;
+  padding-right: 6px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(70, 10, 120, 0.2) transparent;
+}
+
+.project-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.project-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.project-list::-webkit-scrollbar-thumb {
+  background: rgba(70, 10, 120, 0.2);
+  border-radius: 999px;
 }
 
 .project-card {
   background: #fff;
-  border-radius: 12px;
+  border-radius: 16px;
   border: 1px solid transparent;
-  padding: 14px 16px;
+  padding: 16px 18px;
   cursor: pointer;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.06);
-  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+  box-shadow: 0 6px 18px rgba(33, 20, 52, 0.08);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-height: 65px;
 }
 
 .project-card:hover {
-  border-color: var(--purple);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.12);
+  border-color: rgba(70, 10, 120, 0.45);
+  box-shadow: 0 16px 32px rgba(38, 16, 70, 0.18);
+  transform: translateY(-2px);
 }
 
 .project-card.selected {
-  border-color: var(--violet);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
+  border-color: var(--purple);
+  box-shadow: 0 18px 36px rgba(38, 16, 70, 0.22);
 }
 
-.project-card .status {
-  display: inline-flex;
-  align-items: center;
+.project-card-accent {
+  width: 6px;
+  border-radius: 999px;
+  align-self: stretch;
+}
+
+.project-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1 1 auto;
+}
+
+.project-card-title {
+  display: block;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.project-card-bottom {
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+  align-items: center;
+}
+
+.project-card-status {
   font-size: 13px;
   font-weight: 600;
-  color: #fff;
-  border-radius: 999px;
-  padding: 4px 10px;
+}
+
+.project-card-meta {
+  font-size: 13px;
+  color: var(--muted);
 }
 
 .details {
   background: var(--card);
-  border-radius: 18px;
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
-  padding: 32px;
+  border-radius: 22px;
+  border: 1px solid rgba(70, 10, 120, 0.08);
+  box-shadow: 0 22px 48px rgba(33, 20, 52, 0.12);
+  padding: 40px;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 }
 
 .empty-state {
@@ -195,58 +248,106 @@ p {
   color: var(--muted);
 }
 
-.details-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
+.status-pill {
+  display: inline-flex;
   align-items: center;
-  margin-bottom: 24px;
-}
-
-.details-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
-  margin-bottom: 24px;
-}
-
-.detail-box {
-  background: #fafafa;
-  border-radius: 12px;
-  padding: 16px;
-  border: 1px solid #f0f0f5;
-}
-
-.detail-box h4 {
+  justify-content: center;
+  border-radius: 999px;
+  padding: 6px 18px;
   font-size: 14px;
-  text-transform: uppercase;
-  letter-spacing: 0.6px;
-  margin-bottom: 8px;
+  font-weight: 600;
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(70, 10, 120, 0.25);
+}
+
+.project-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.project-overview__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.project-overview__header > .status-pill {
+  margin-left: auto;
+}
+
+.project-overview__title {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.project-overview__hint {
+  flex-basis: 100%;
+  font-size: 13px;
   color: var(--muted);
 }
 
-.detail-box p {
-  margin: 0;
-  font-size: 15px;
-  line-height: 1.5;
+.project-overview__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
 }
 
-.section-title {
-  margin: 32px 0 12px;
+.project-highlight {
+  background: #f8f9fb;
+  border: 1px solid #ececf2;
+  border-radius: 16px;
+  padding: 18px 20px;
+  min-height: 65px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.project-highlight__label {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  color: var(--muted);
+}
+
+.project-highlight__value {
   font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
 }
 
-.inline-list {
+.project-highlight__value--budget {
+  color: #0a9c63;
+}
+
+.project-description {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.inline-list article {
-  border-radius: 12px;
-  border: 1px solid #f0f0f5;
-  padding: 16px;
-  background: #fafafa;
+.project-description h3 {
+  font-size: 18px;
+}
+
+.project-description__text {
+  margin: 0;
+  background: #f8f9fb;
+  border: 1px solid #ececf2;
+  border-radius: 18px;
+  padding: 20px 24px;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+.project-overview__actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 /* ============================================================ */
@@ -419,6 +520,35 @@ p {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.gantt-container {
+  margin-top: 12px;
+  padding: 18px;
+  border-radius: 14px;
+  border: 1px solid #ededf5;
+  background: #f5f1fb;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.gantt-container h3 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.gantt-chart {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: 8px;
+  background: #fff;
+  padding: 4px;
+  box-shadow: inset 0 0 0 1px rgba(70, 10, 120, 0.08);
+}
+
+.gantt-chart > div {
+  min-width: 480px;
 }
 
 @media (max-width: 1080px) {


### PR DESCRIPTION
## Summary
- redesign the project list to use accent bars, compact metadata and a minimalist scrollbar that mirrors the provided mockup
- rebuild the project detail panel into highlight cards and a concise description section with updated action buttons and status pill styling
- refresh global styles to support the new layout, including larger cards, unified spacing and an updated sidebar presentation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cabe490f5883339319c420ad015e49