### PR TITLE
Move status pill to right in details header

### DIFF
--- a/script.js
+++ b/script.js
@@ -574,14 +574,14 @@ function renderProjectDetails(detail) {
 
   const header = document.createElement('div');
   header.className = 'project-overview__header';
+  const title = document.createElement('h2');
+  title.className = 'project-overview__title';
+  title.textContent = project.Title || 'Projeto sem título';
   const status = document.createElement('span');
   status.className = 'status-pill';
   status.style.background = statusColor(project.status);
   status.textContent = project.status || 'Sem status';
-  const title = document.createElement('h2');
-  title.className = 'project-overview__title';
-  title.textContent = project.Title || 'Projeto sem título';
-  header.append(status, title);
+  header.append(title, status);
 
   if (project.status === 'Aprovado') {
     const info = document.createElement('p');

--- a/style.css
+++ b/style.css
@@ -349,6 +349,10 @@ p {
   box-shadow: 0 8px 20px rgba(70, 10, 120, 0.25);
 }
 
+.project-overview__header .status-pill {
+  margin-left: auto;
+}
+
 .project-overview {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- reorder the project details header so the title comes before the status chip
- adjust the status pill styling so it aligns to the right edge of the details header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb5b4f184c83339ed1f79b4d1e43a2