### PR TITLE
feat: allow closing overlay with escape key

### DIFF
--- a/script.js
+++ b/script.js
@@ -384,6 +384,8 @@ function init() {
 function bindEvents() {
   newProjectBtn.addEventListener('click', () => openProjectForm('create'));
   closeFormBtn.addEventListener('click', closeForm);
+  // Habilita o fechamento do formulário pela tecla ESC.
+  document.addEventListener('keydown', handleOverlayEscape);
   if (projectSearch) {
     projectSearch.addEventListener('input', () => renderProjectList());
   }
@@ -847,6 +849,17 @@ function fillFormWithProject(detail) {
 
 function closeForm() {
   overlay.classList.add('hidden');
+}
+
+/**
+ * Fecha o formulário quando o usuário pressiona ESC.
+ * A verificação garante que a overlay exista e esteja visível,
+ * evitando erros quando o formulário já está fechado.
+ */
+function handleOverlayEscape(event) {
+  if (event.key !== 'Escape') return;
+  if (!overlay || overlay.classList.contains('hidden')) return;
+  closeForm();
 }
 
 function updateBudgetSections(options = {}) {


### PR DESCRIPTION
## Summary
- enable closing the overlay form with the Escape key
- guard against redundant closes by checking overlay visibility before hiding it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb5d6340b08333af033ea1fb855846