### PR TITLE
Confirm overlay close on ESC

### DIFF
--- a/script.js
+++ b/script.js
@@ -853,13 +853,21 @@ function closeForm() {
 
 /**
  * Fecha o formulário quando o usuário pressiona ESC.
+ * Ao detectar a tecla, confirma com o usuário antes de fechar o formulário.
  * A verificação garante que a overlay exista e esteja visível,
  * evitando erros quando o formulário já está fechado.
  */
 function handleOverlayEscape(event) {
   if (event.key !== 'Escape') return;
   if (!overlay || overlay.classList.contains('hidden')) return;
-  closeForm();
+
+  const shouldClose = window.confirm(
+    'Tem certeza que deseja fechar o formulário? Suas alterações não salvas serão perdidas.'
+  );
+
+  if (shouldClose) {
+    closeForm();
+  }
 }
 
 function updateBudgetSections(options = {}) {


### PR DESCRIPTION
## Summary
- prompt users with a confirmation dialog before closing the form overlay via the Escape key
- ensure the overlay only closes when confirmed, keeping the form visible otherwise

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb5e5ac1f0833386d060530dd323c1