### PR TITLE
Add project submission summary overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,10 +280,39 @@
       </fieldset>
 
       <div class="form-actions">
-        <button type="submit" id="saveProjectBtn" class="btn primary">Salvar</button>
+        <button type="button" id="saveProjectBtn" class="btn primary">Salvar</button>
         <button type="button" id="sendApprovalBtn" class="btn accent">Enviar para Aprovação</button>
       </div>
     </form>
+  </div>
+
+  <div
+    id="summaryOverlay"
+    class="overlay overlay-summary hidden"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="summaryTitle"
+    tabindex="-1"
+  >
+    <div class="summary-panel">
+      <header class="summary-header">
+        <h2 id="summaryTitle">Resumo do Projeto</h2>
+        <p class="summary-subtitle">Revise as informações antes de confirmar o envio.</p>
+      </header>
+
+      <div class="summary-body">
+        <div id="summarySections" class="summary-sections"></div>
+        <div id="summaryGanttSection" class="summary-gantt hidden">
+          <h3>Cronograma do Projeto</h3>
+          <div id="summaryGanttChart" class="gantt-chart"></div>
+        </div>
+      </div>
+
+      <footer class="summary-actions">
+        <button type="button" id="summaryEditBtn" class="btn ghost">Voltar e Editar</button>
+        <button type="button" id="summaryConfirmBtn" class="btn primary">Confirmar Envio</button>
+      </footer>
+    </div>
   </div>
 
   <!-- =============================================================== -->

--- a/style.css
+++ b/style.css
@@ -480,6 +480,202 @@ p {
   gap: 28px;
 }
 
+.overlay-summary {
+  align-items: center;
+  z-index: 20;
+}
+
+.overlay-summary .summary-panel {
+  background: #fff;
+  border-radius: 20px;
+  width: 100%;
+  max-width: 960px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.25);
+  padding: 32px 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-height: calc(100vh - 80px);
+}
+
+.overlay-summary .summary-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.overlay-summary .summary-subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.overlay-summary .summary-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding-right: 8px;
+}
+
+.summary-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.summary-section {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px 24px;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.summary-section h3 {
+  font-size: 18px;
+  margin: 0;
+}
+
+.summary-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px 24px;
+  margin: 0;
+}
+
+.summary-list.summary-list--activity {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.summary-list dt {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.summary-list dd {
+  margin: 0;
+  font-size: 15px;
+  color: var(--text);
+  white-space: pre-wrap;
+}
+
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.summary-table th,
+.summary-table td {
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+  text-align: left;
+}
+
+.summary-table th {
+  background: rgba(70, 10, 120, 0.06);
+  font-weight: 600;
+  color: var(--purple);
+}
+
+.summary-milestones {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.summary-milestone {
+  border: 1px solid #ededf5;
+  border-radius: 14px;
+  padding: 18px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.summary-milestone h4 {
+  margin: 0;
+  font-size: 17px;
+}
+
+.summary-activities {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.summary-activity {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+  background: #faf6ff;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.summary-activity h5 {
+  margin: 0;
+  font-size: 16px;
+  color: var(--purple);
+}
+
+.summary-gantt {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px 24px;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.summary-gantt.hidden {
+  display: none;
+}
+
+.summary-actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.summary-actions .btn {
+  min-width: 160px;
+}
+
+@media (max-width: 768px) {
+  .overlay-summary {
+    padding: 24px 16px;
+  }
+
+  .overlay-summary .summary-panel {
+    padding: 24px;
+    max-height: calc(100vh - 48px);
+  }
+
+  .summary-list {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-actions {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+}
+
 .form-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add a project summary overlay that appears when saving or sending for approval
- style the overlay with sections, tables, and gantt preview using the existing visual language
- update form logic to populate the summary, copy the gantt chart, and only submit after confirmation

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cb65bbec648333bc5b59909f247ce5