### PR TITLE
Fix approval year field behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
         <div class="field-grid">
           <div class="field-group">
             <label for="approvalYear">Ano de Aprovação</label>
-            <input id="approvalYear" name="approvalYear" type="number" min="1900" max="9999" required>
+            <input id="approvalYear" name="approvalYear" type="number" min="1900" max="9999" required readonly>
           </div>
           <div class="field-group">
             <label for="investmentLevel">Nível de Investimento</label>

--- a/script.js
+++ b/script.js
@@ -387,11 +387,18 @@ function drawGantt(milestones) {
 // ============================================================================
 // Inicialização
 // ============================================================================
-function init() {
-  bindEvents();
+function setApprovalYearToCurrent() {
+  if (!approvalYearInput) {
+    return;
+  }
   const currentYear = new Date().getFullYear();
   approvalYearInput.value = currentYear;
   approvalYearInput.max = currentYear;
+}
+
+function init() {
+  bindEvents();
+  setApprovalYearToCurrent();
   loadProjects();
   initGantt();
   window.addEventListener('load', initGantt, { once: true });
@@ -814,6 +821,7 @@ function openProjectForm(mode, detail = null) {
     formTitle.textContent = 'Novo Projeto';
     statusField.value = 'Rascunho';
     sendApprovalBtn.classList.remove('hidden');
+    setApprovalYearToCurrent();
     updateBudgetSections({ clear: true });
   } else if (detail) {
     fillFormWithProject(detail);


### PR DESCRIPTION
## Summary
- mark the approval year field as read-only in the form markup
- ensure the current year is applied on initialization and when opening a new project form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc115421948333bf9b14deeee1de73