### PR TITLE
Implement cascading company dropdowns

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,46 +119,33 @@
           <div class="field-group">
             <label for="company">Empresa</label>
             <select id="company" name="company" required>
-              <option value="">Selecione a empresa</option>
-              <option>BMJF</option>
-              <option>BF00</option>
-              <option>ACBF</option>
+              <option value="">Selecione...</option>
+              <option>Empresa 01</option>
+              <option>Empresa 02</option>
             </select>
           </div>
           <div class="field-group">
             <label for="center">Centro</label>
             <select id="center" name="center" required>
-              <option value="">Selecione o centro</option>
-              <option>Opção 1</option>
-              <option>Opção 2</option>
-              <option>Opção 3</option>
+              <option value="">Selecione...</option>
             </select>
           </div>
           <div class="field-group">
             <label for="unit">Unidade</label>
             <select id="unit" name="unit" required>
-              <option value="">Selecione a unidade</option>
-              <option>Opção 1</option>
-              <option>Opção 2</option>
-              <option>Opção 3</option>
+              <option value="">Selecione...</option>
             </select>
           </div>
           <div class="field-group">
             <label for="location">Local de Implantação</label>
             <select id="location" name="location" required>
-              <option value="">Selecione a localização</option>
-              <option>Opção 1</option>
-              <option>Opção 2</option>
-              <option>Opção 3</option>
+              <option value="">Selecione...</option>
             </select>
           </div>
           <div class="field-group">
-            <label for="depreciationCostCenter">C Custo Depreciação</label>
+            <label for="depreciationCostCenter">C. Custo Depreciação</label>
             <select id="depreciationCostCenter" name="depreciationCostCenter" required>
-              <option value="">Selecione o C. Custo Depreciação</option>
-              <option>Opção 1</option>
-              <option>Opção 2</option>
-              <option>Opção 3</option>
+              <option value="">Selecione...</option>
             </select>
           </div>
           <div class="field-group">


### PR DESCRIPTION
## Summary
- add company rule map and helper functions to populate dependent selects based on the chosen company
- reset dependent selects when opening the form and when the company changes, while preserving stored selections on edit
- update HTML placeholders and labels to match the cascading dropdown behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc14404c20833392cff725d24746a7