### PR TITLE
Add live budget and date validation hints

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,6 @@
         <div class="field-group">
           <label for="projectBudget">Orçamento do Projeto em R$</label>
           <input id="projectBudget" name="projectBudget" type="number" min="0" step="0.01" required>
-          <small id="budgetHint" class="hint"></small>
         </div>
         <div class="field-grid">
           <div class="field-group">
@@ -269,6 +268,9 @@
           <div id="ganttChart" class="gantt-chart" role="img" aria-label="Gráfico de Gantt do projeto"></div>
         </div>
       </fieldset>
+
+      <p id="budgetHint" class="hint" aria-live="polite"></p>
+      <p id="dateHint" class="hint" aria-live="polite"></p>
 
       <div class="form-actions">
         <button type="button" id="saveProjectBtn" class="btn primary">Salvar</button>


### PR DESCRIPTION
## Summary
- add dedicated feedback elements for orçamento restante and datas de atividades
- implement live budget remaining calculation with color-coded messaging
- provide real-time activity date validation with success and warning hints

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc19016cd483338521beb8f0d85a0d