### PR TITLE
Ajusta fluxo de envio de projetos

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,6 @@
 
       <div class="form-actions">
         <button type="button" id="saveProjectBtn" class="btn primary">Salvar</button>
-        <button type="button" id="sendApprovalBtn" class="btn accent">Enviar para Aprovação</button>
       </div>
     </form>
   </div>
@@ -303,7 +302,7 @@
 
       <footer class="summary-actions">
         <button type="button" id="summaryEditBtn" class="btn ghost">Voltar e Editar</button>
-        <button type="button" id="summaryConfirmBtn" class="btn primary">Confirmar Envio</button>
+        <button type="button" id="summaryConfirmBtn" class="btn primary">Confirmar</button>
       </footer>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- ajusta o formulário para abrir o resumo ao salvar e confirmações sempre em "Rascunho"
- exibe mensagens de feedback ao salvar e renomeia ações do resumo
- adiciona envio para aprovação a partir dos projetos em rascunho na tela inicial

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68cc424fabe48333bbd459d5b9c17e44