### PR TITLE
Improve form validation feedback and summaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,8 +50,13 @@
 
       <input type="hidden" id="statusField" value="Rascunho">
 
-      <div id="formStatus" class="feedback" aria-live="polite"></div>
-      <div id="formErrors" class="feedback error" aria-live="assertive"></div>
+      <div class="form-feedback">
+        <div id="formStatus" class="feedback" role="alert" aria-live="polite"></div>
+        <div id="formErrors" class="feedback" role="alert" aria-live="assertive">
+          <strong id="formErrorsTitle" class="feedback-title"></strong>
+          <ul id="errorSummaryList" class="error-summary"></ul>
+        </div>
+      </div>
 
       <!-- ============================== -->
       <!-- 1. Sobre o Projeto             -->

--- a/style.css
+++ b/style.css
@@ -773,22 +773,142 @@ p {
   font-size: 13px;
 }
 
+.form-feedback {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
 .feedback {
   border-radius: 12px;
   padding: 12px 16px;
-  background: rgba(70, 10, 120, 0.08);
-  color: var(--purple);
   display: none;
+  border: 1px solid transparent;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
 .feedback.show {
   display: block;
 }
 
-.feedback.error {
-  background: rgba(230, 60, 65, 0.12);
-  color: var(--red);
-  border: 1px solid rgba(230, 60, 65, 0.25);
+.feedback--info {
+  background: rgba(70, 10, 120, 0.08);
+  color: var(--purple);
+  border-color: rgba(70, 10, 120, 0.15);
+}
+
+.feedback--success {
+  background: #e6f4ea;
+  color: #1b5e20;
+  border-color: #b7dfb9;
+}
+
+.feedback--warning {
+  background: #fff8e1;
+  color: #a15c0c;
+  border-color: #ffe0a3;
+}
+
+.feedback--error {
+  background: #fdecea;
+  color: #c62828;
+  border-color: #f4b4b4;
+}
+
+.feedback-title {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.error-summary {
+  margin: 0;
+  padding-left: 20px;
+  list-style: disc;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.error-summary > li {
+  list-style: disc;
+}
+
+.error-summary ul {
+  margin: 6px 0 0;
+  padding-left: 18px;
+  list-style: disc;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.error-summary__item {
+  list-style: disc;
+}
+
+.error-summary__sublist {
+  margin: 6px 0 0;
+  padding-left: 18px;
+  list-style: disc;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-control {
+  display: block;
+  width: 100%;
+}
+
+.field-group.has-error {
+  gap: 10px;
+}
+
+.field-group.has-error label {
+  color: #c62828;
+}
+
+.field-group.has-error .field-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.field-group.has-error .field-control > input,
+.field-group.has-error .field-control > select,
+.field-group.has-error .field-control > textarea {
+  flex: 1 1 auto;
+}
+
+.field-group.has-error input,
+.field-group.has-error select,
+.field-group.has-error textarea,
+.field-invalid {
+  border-color: rgba(230, 60, 65, 0.6);
+  box-shadow: 0 0 0 1px rgba(230, 60, 65, 0.18);
+}
+
+.field-group.has-error input:focus,
+.field-group.has-error select:focus,
+.field-group.has-error textarea:focus {
+  outline-color: rgba(230, 60, 65, 0.4);
+}
+
+.field-error {
+  color: #c62828;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: normal;
+  max-width: 280px;
+}
+
+.field-error::before {
+  content: '⚠️';
 }
 
 .form-actions {


### PR DESCRIPTION
## Summary
- add a dedicated feedback area with success, warning, and error alerts plus an error summary list
- enhance form validation to track detailed issues, highlight offending fields, and present budget/date-specific guidance
- centralize validation flow to gate saving, focus the first invalid control, and surface SharePoint save errors in the summary panel

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc8acfff2c8333801bd3930ef87396