### PR TITLE
Add validation and KPI data fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
         </div>
         <div class="field-group">
           <label for="proposedSolution">Solução da Proposta</label>
-          <textarea id="proposedSolution" name="proposedSolution" rows="4"></textarea>
+          <textarea id="proposedSolution" name="proposedSolution" rows="4" required></textarea>
         </div>
       </fieldset>
 
@@ -235,7 +235,7 @@
         <div class="field-grid">
           <div class="field-group">
             <label for="kpiType">Tipo de KPI</label>
-            <select id="kpiType" name="kpiType">
+            <select id="kpiType" name="kpiType" required>
               <option value="">Selecione o tipo de KPI</option>
               <option>Produtividade</option>
               <option>Saúde e Segurança</option>
@@ -243,20 +243,20 @@
           </div>
           <div class="field-group">
             <label for="kpiName">Nome do KPI</label>
-            <input id="kpiName" name="kpiName" type="text" maxlength="160" placeholder="Digite o nome do KPI">
+            <input id="kpiName" name="kpiName" type="text" maxlength="160" placeholder="Digite o nome do KPI" required>
           </div>
           <div class="field-group">
             <label for="kpiCurrent">KPI Atual</label>
-            <input id="kpiCurrent" name="kpiCurrent" type="text" maxlength="160" placeholder="Digite o KPI atual">
+            <input id="kpiCurrent" name="kpiCurrent" type="text" maxlength="160" placeholder="Digite o KPI atual" required>
           </div>
           <div class="field-group">
             <label for="kpiExpected">KPI Esperado</label>
-            <input id="kpiExpected" name="kpiExpected" type="text" maxlength="160" placeholder="Digite o KPI esperado">
+            <input id="kpiExpected" name="kpiExpected" type="text" maxlength="160" placeholder="Digite o KPI esperado" required>
           </div>
         </div>
         <div class="field-group">
           <label for="kpiDescription">Descrição do KPI</label>
-          <textarea id="kpiDescription" name="kpiDescription" rows="3"></textarea>
+          <textarea id="kpiDescription" name="kpiDescription" rows="3" required></textarea>
         </div>
       </fieldset>
 
@@ -393,11 +393,11 @@
       <input type="hidden" class="activity-pep-year">
       <div class="field-group full-width">
         <label>Fornecedor</label>
-        <input type="text" class="activity-supplier" maxlength="160">
+        <input type="text" class="activity-supplier" maxlength="160" required>
       </div>
       <div class="field-group full-width">
         <label>Descrição Geral da Atividade</label>
-        <textarea class="activity-description" rows="5"></textarea>
+        <textarea class="activity-description" rows="5" required></textarea>
       </div>
       <button type="button" class="icon-btn remove-activity" aria-label="Remover atividade">
         <span class="material-symbols-outlined" aria-hidden="true">delete</span>

--- a/script.js
+++ b/script.js
@@ -2634,8 +2634,8 @@ function collectProjectData() {
     kpiType: document.getElementById('kpiType').value.trim(),
     kpiName: document.getElementById('kpiName').value.trim(),
     kpiDescription: document.getElementById('kpiDescription').value.trim(),
-    kpiCurrent: parseFloatOrNull(document.getElementById('kpiCurrent').value),
-    kpiExpected: parseFloatOrNull(document.getElementById('kpiExpected').value)
+    kpiCurrent: document.getElementById('kpiCurrent').value.trim(),
+    kpiExpected: document.getElementById('kpiExpected').value.trim()
   };
   return data;
 }
@@ -2867,11 +2867,6 @@ function statusColor(status) {
 
 function parseNumber(value) {
   const number = parseInt(value, 10);
-  return Number.isFinite(number) ? number : null;
-}
-
-function parseFloatOrNull(value) {
-  const number = parseFloat(value);
   return Number.isFinite(number) ? number : null;
 }
 


### PR DESCRIPTION
## Summary
- require the proposed solution, KPI and activity supplier/description fields so they are validated before submission
- send KPI current and expected values as the user entered text so they reach the SharePoint list

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc910047a883338ea2e32bb6350863