### PR TITLE
Fix validation error layout for project form fields

### DIFF
--- a/style.css
+++ b/style.css
@@ -873,14 +873,16 @@ p {
 
 .field-group.has-error .field-control {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
 }
 
 .field-group.has-error .field-control > input,
 .field-group.has-error .field-control > select,
 .field-group.has-error .field-control > textarea {
-  flex: 1 1 auto;
+  flex: initial;
+  width: 100%;
 }
 
 .field-group.has-error input,
@@ -900,11 +902,11 @@ p {
 .field-error {
   color: #c62828;
   font-size: 13px;
-  display: flex;
-  align-items: center;
+  display: inline-flex;
+  align-items: flex-start;
   gap: 6px;
   white-space: normal;
-  max-width: 280px;
+  max-width: 100%;
 }
 
 .field-error::before {


### PR DESCRIPTION
## Summary
- ensure field validation messages stack below the controls instead of shrinking them
- allow error helper text to span the full width so text areas keep their size

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc96af920883339dcb6d92a2b5b3cd