### PR TITLE
Fix form control width reset after validation

### DIFF
--- a/style.css
+++ b/style.css
@@ -863,6 +863,12 @@ p {
   width: 100%;
 }
 
+.field-control > input,
+.field-control > select,
+.field-control > textarea {
+  width: 100%;
+}
+
 .field-group.has-error {
   gap: 10px;
 }


### PR DESCRIPTION
## Summary
- ensure inputs, selects and textareas wrapped by the validation helper keep their full width
- prevent the form fields from shrinking after closing and reopening the "Novo Projeto" modal

## Testing
- no automated tests were run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc9a4e897083339fc4e0b75d7de28d