### PR TITLE
Ajusta formulário de projetos para modo somente leitura por status

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,25 @@
         </div>
       </div>
 
+      <div id="formSummaryView" class="summary-panel form-summary hidden" aria-live="polite">
+        <header class="summary-header">
+          <h2 id="formSummaryTitle">Resumo do Projeto</h2>
+          <p class="summary-subtitle">Visualização apenas leitura dos dados do projeto.</p>
+        </header>
+
+        <div class="summary-body">
+          <div id="formSummarySections" class="summary-sections"></div>
+          <section id="formSummaryGanttSection" class="summary-section summary-gantt hidden">
+            <h3>Gráfico Gantt</h3>
+            <div id="formSummaryGanttChart" class="gantt-chart"></div>
+          </section>
+        </div>
+
+        <footer class="summary-actions">
+          <button type="button" id="formSummaryCloseBtn" class="btn secondary">Fechar</button>
+        </footer>
+      </div>
+
       <!-- ============================== -->
       <!-- 1. Sobre o Projeto             -->
       <!-- ============================== -->
@@ -278,6 +297,7 @@
       <p id="dateHint" class="hint" aria-live="polite"></p>
 
       <div class="form-actions">
+        <button type="button" id="submitForApprovalBtn" class="btn accent">Enviar para Aprovação</button>
         <button type="button" id="saveProjectBtn" class="btn primary">Salvar</button>
       </div>
     </form>

--- a/style.css
+++ b/style.css
@@ -491,6 +491,54 @@ p {
   gap: 28px;
 }
 
+.form-summary {
+  display: none;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form-summary .summary-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-summary .summary-subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.form-summary .summary-body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form-summary .summary-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.project-form--readonly {
+  padding: 32px 36px;
+  gap: 0;
+}
+
+.project-form--readonly .form-summary {
+  display: flex;
+}
+
+.project-form--readonly .form-feedback,
+.project-form--readonly .form-section,
+.project-form--readonly #budgetHint,
+.project-form--readonly #dateHint,
+.project-form--readonly .form-actions,
+.project-form--readonly .form-header {
+  display: none;
+}
+
 .overlay-summary {
   align-items: center;
   z-index: 20;


### PR DESCRIPTION
## Summary
- aplica modo de visualização somente leitura com resumo e gráfico Gantt para projetos aprovados, reprovados ou em aprovação
- mantém formulário em edição para rascunhos ou itens reprovados para revisão exibindo botões de salvar e enviar para aprovação
- reaproveita a lógica de geração do resumo para múltiplos contextos e ajusta o fluxo de envio para registrar a intenção de aprovação

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc9f0a92b08333a220db94d29e2b35