### PR TITLE
Implement project summary PDF attachment workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,6 +426,8 @@
   </template>
 
   <script src="https://www.gstatic.com/charts/loader.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="script.js" type="module"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -579,6 +579,41 @@ p {
   padding-right: 8px;
 }
 
+.summary-panel--capture {
+  position: fixed;
+  left: -1200px;
+  top: 0;
+  width: 960px;
+  max-width: 960px;
+  background: #fff;
+  border-radius: 20px;
+  padding: 32px 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  pointer-events: none;
+  z-index: -1;
+  color: #1f1f3d;
+}
+
+.summary-panel--capture .summary-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.summary-panel--capture .summary-subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.summary-panel--capture .summary-body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
 .summary-sections {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- generate a project summary PDF on approval using html2canvas/jsPDF and upload it to SharePoint as an attachment with configurable naming
- add a hidden summary capture layout and SharePoint attachment helpers to support PDF generation while preserving existing summary rendering
- adjust status handling to allow edits after rejection, enforce read-only for approved/in-approval projects, and route approval actions through the summary overlay

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccaa41b1a8833391d71cd6c2928f27