### PR TITLE
Evita criar PEP vazio ao carregar formulário

### DIFF
--- a/script.js
+++ b/script.js
@@ -2124,7 +2124,7 @@ function updateBudgetSections(options = {}) {
     if (!preserve) {
       milestoneList.innerHTML = '';
     }
-    if (!simplePepList.children.length) {
+    if (!simplePepList.children.length && !preserve) {
       ensureSimplePepRow();
     }
   }


### PR DESCRIPTION
## Summary
- evita adicionar automaticamente uma linha de PEP vazia ao reexibir a seção em modo de preservação
- mantém a geração automática apenas quando o formulário exige uma nova linha

## Testing
- não executado (não há testes automatizados disponíveis)


------
https://chatgpt.com/codex/tasks/task_e_68cd3de05a1c8333b6df2a6e9d6ec541