### PR TITLE
Adjust PDF generation workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,7 +297,6 @@
       <p id="dateHint" class="hint" aria-live="polite"></p>
 
       <div class="form-actions">
-        <button type="button" id="submitForApprovalBtn" class="btn accent">Enviar para Aprovação</button>
         <button type="button" id="saveProjectBtn" class="btn primary">Salvar</button>
       </div>
     </form>


### PR DESCRIPTION
## Summary
- ensure the form actions present only the save button while leaving approval for the project cards
- load html2canvas and jsPDF UMD bundles ahead of the application script and rework PDF generation to rely on window namespaces with clear error handling
- generate and upload the summary PDF only when sending a project for approval, keeping drafts from overwriting attachments

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd45aae5308333aa4ad2adad2d47f6