### PR TITLE
Refactor PDF generation and attachment handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,8 +425,8 @@
   </template>
 
   <script src="https://www.gstatic.com/charts/loader.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-  <script src="script.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+  <script src="script.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load html2canvas and jsPDF directly in index.html with defer attributes to avoid RequireJS conflicts
- rebuild summary PDF generation to render the overlay (including the Gantt chart) with html2canvas and jsPDF and return a Blob
- save the generated PDF as an attachment only during approval submissions using the SharePoint service API

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd4db8f9fc8333afe3f654f2795b49