### PR TITLE
Handle AMD globals around PDF libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,8 +425,49 @@
   </template>
 
   <script src="https://www.gstatic.com/charts/loader.js"></script>
+  <script>
+    (function (w) {
+      w.__amdDefineBackup__ = w.define;
+      w.__amdRequireBackup__ = w.require;
+      w.__amdRequireJsBackup__ = w.requirejs;
+
+      w.define = undefined;
+      w.require = undefined;
+      w.requirejs = undefined;
+    })(window);
+  </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+  <script>
+    (function (w) {
+      if (Object.prototype.hasOwnProperty.call(w, "__amdDefineBackup__")) {
+        if (typeof w.__amdDefineBackup__ === "undefined") {
+          delete w.define;
+        } else {
+          w.define = w.__amdDefineBackup__;
+        }
+        delete w.__amdDefineBackup__;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(w, "__amdRequireBackup__")) {
+        if (typeof w.__amdRequireBackup__ === "undefined") {
+          delete w.require;
+        } else {
+          w.require = w.__amdRequireBackup__;
+        }
+        delete w.__amdRequireBackup__;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(w, "__amdRequireJsBackup__")) {
+        if (typeof w.__amdRequireJsBackup__ === "undefined") {
+          delete w.requirejs;
+        } else {
+          w.requirejs = w.__amdRequireJsBackup__;
+        }
+        delete w.__amdRequireJsBackup__;
+      }
+    })(window);
+  </script>
   <script src="script.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- save existing AMD globals before loading html2canvas and jsPDF
- temporarily disable AMD globals to allow the UMD bundles to attach to window
- restore any original AMD globals after the PDF libraries load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd524f21948333965b07003d2b7a9c