### PR TITLE
Remove defer from PDF library scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,8 +436,8 @@
       w.requirejs = undefined;
     })(window);
   </script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" defer></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script>
     (function (w) {
       if (Object.prototype.hasOwnProperty.call(w, "__amdDefineBackup__")) {


### PR DESCRIPTION
## Summary
- load html2canvas and jsPDF synchronously so they attach to window before AMD globals are restored

## Testing
- manual verification in browser console to confirm html2canvas and jsPDF globals exist and generateSummaryPdfBlob runs

------
https://chatgpt.com/codex/tasks/task_e_68cd54d5162c8333bd82567518f1df3e