### PR TITLE
Fix PDF generation conflicts with RequireJS and capture Gantt image

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,8 +436,16 @@
       w.requirejs = undefined;
     })(window);
   </script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script
+    src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  ></script>
+  <script
+    src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  ></script>
   <script>
     (function (w) {
       if (Object.prototype.hasOwnProperty.call(w, "__amdDefineBackup__")) {


### PR DESCRIPTION
## Summary
- ensure html2canvas and jsPDF scripts are loaded with CORS-friendly settings so they register correctly alongside SharePoint's RequireJS setup
- replace the PDF export pipeline to temporarily disable AMD, capture the Gantt chart as an image, and attach the generated blob to SharePoint

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cd5b33514c833381b9009fe88696f4