### PR TITLE
Refatorar envio para aprovação com resumo em JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,57 +425,6 @@
   </template>
 
   <script src="https://www.gstatic.com/charts/loader.js"></script>
-  <script>
-    (function (w) {
-      w.__amdDefineBackup__ = w.define;
-      w.__amdRequireBackup__ = w.require;
-      w.__amdRequireJsBackup__ = w.requirejs;
-
-      w.define = undefined;
-      w.require = undefined;
-      w.requirejs = undefined;
-    })(window);
-  </script>
-  <script
-    src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"
-    crossorigin="anonymous"
-    referrerpolicy="no-referrer"
-  ></script>
-  <script
-    src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"
-    crossorigin="anonymous"
-    referrerpolicy="no-referrer"
-  ></script>
-  <script>
-    (function (w) {
-      if (Object.prototype.hasOwnProperty.call(w, "__amdDefineBackup__")) {
-        if (typeof w.__amdDefineBackup__ === "undefined") {
-          delete w.define;
-        } else {
-          w.define = w.__amdDefineBackup__;
-        }
-        delete w.__amdDefineBackup__;
-      }
-
-      if (Object.prototype.hasOwnProperty.call(w, "__amdRequireBackup__")) {
-        if (typeof w.__amdRequireBackup__ === "undefined") {
-          delete w.require;
-        } else {
-          w.require = w.__amdRequireBackup__;
-        }
-        delete w.__amdRequireBackup__;
-      }
-
-      if (Object.prototype.hasOwnProperty.call(w, "__amdRequireJsBackup__")) {
-        if (typeof w.__amdRequireJsBackup__ === "undefined") {
-          delete w.requirejs;
-        } else {
-          w.requirejs = w.__amdRequireJsBackup__;
-        }
-        delete w.__amdRequireJsBackup__;
-      }
-    })(window);
-  </script>
   <script src="script.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove a integração anterior de html2canvas e jsPDF do projeto
- gerar o resumo do envio para aprovação como JSON com dados do projeto, marcos, atividades e PEPs
- anexar o resumo.json ao item do projeto no SharePoint sobrescrevendo anexos anteriores e manter o status atualizado

## Testing
- not run (não há testes automatizados disponíveis)


------
https://chatgpt.com/codex/tasks/task_e_68cd5e287e3c83339e7052b5b99a8fbc