### PR TITLE
Fix SharePoint deleteAttachment URL syntax

### DIFF
--- a/script.js
+++ b/script.js
@@ -97,7 +97,7 @@ class SharePointService {
     const sanitizedName = this.sanitizeFileName(fileName || '');
     const url = this.buildUrl(
       listName,
-      `/items(${itemId})/AttachmentFiles/getByFileName(fileName='${sanitizedName}')`
+      `/items(${itemId})/AttachmentFiles/getByFileName('${sanitizedName}')`
     );
     await this.request(url, { method: 'POST', headers });
     return true;


### PR DESCRIPTION
## Summary
- correct SharePoint deleteAttachment REST endpoint to drop the invalid fileName= segment

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd61376e908333988fa3997ec909eb