### PR TITLE
Fix SharePoint getByFileName encoding for attachment deletion

### DIFF
--- a/script.js
+++ b/script.js
@@ -95,9 +95,10 @@ class SharePointService {
       'X-HTTP-Method': 'DELETE'
     };
     const sanitizedName = this.sanitizeFileName(fileName || '');
+    const encodedName = encodeURIComponent(sanitizedName);
     const url = this.buildUrl(
       listName,
-      `/items(${itemId})/AttachmentFiles/getByFileName('${sanitizedName}')`
+      `/items(${itemId})/AttachmentFiles/getByFileName('${encodedName}')`
     );
     await this.request(url, { method: 'POST', headers });
     return true;


### PR DESCRIPTION
## Summary
- encode the SharePoint attachment delete route using the correct getByFileName pattern
- ensure filenames are URL encoded to handle special characters

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd63f47ab0833380e896248d1989bd