### PR TITLE
Update SharePoint summary attachment file extension

### DIFF
--- a/script.js
+++ b/script.js
@@ -48,7 +48,7 @@ class SharePointService {
     }
 
     const { overwrite = false, contentType = 'application/octet-stream' } = options;
-    const normalizedFileName = this.sanitizeFileName(fileName || 'anexo.pdf');
+    const normalizedFileName = this.sanitizeFileName(fileName || 'resumo.txt');
 
     if (overwrite) {
       try {
@@ -94,7 +94,7 @@ class SharePointService {
       'IF-MATCH': '*',
       'X-HTTP-Method': 'DELETE'
     };
-    const sanitizedName = this.sanitizeFileName(fileName || '');
+    const sanitizedName = this.sanitizeFileName(fileName || 'resumo.txt');
     const encodedName = encodeURIComponent(sanitizedName);
     const url = this.buildUrl(
       listName,
@@ -2947,7 +2947,7 @@ async function handleFormSubmit(event) {
       const jsonContent = JSON.stringify(approvalSummary, null, 2);
       const jsonBlob = new Blob([jsonContent], { type: 'application/json' });
 
-      await sp.addAttachment('Projects', resolvedId, 'resumo.json', jsonBlob, {
+      await sp.addAttachment('Projects', resolvedId, 'resumo.txt', jsonBlob, {
         overwrite: true,
         contentType: 'application/json'
       });


### PR DESCRIPTION
## Summary
- change the SharePoint attachment helper to default to `resumo.txt`
- update approval submission to upload the summary as `resumo.txt`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd676042788333a7056e2b768bcf81