### PR TITLE
Fix SharePoint attachment filename encoding

### DIFF
--- a/script.js
+++ b/script.js
@@ -48,7 +48,8 @@ class SharePointService {
     }
 
     const { overwrite = false, contentType = 'application/octet-stream' } = options;
-    const normalizedFileName = this.sanitizeFileName(fileName || 'resumo.txt');
+    const normalizedFileName = this.sanitizeFileName(fileName || `resumo_${itemId}.txt`);
+    const safeFileName = encodeURIComponent(normalizedFileName);
 
     if (overwrite) {
       try {
@@ -68,7 +69,7 @@ class SharePointService {
     };
     const url = this.buildUrl(
       listName,
-      `/items(${itemId})/AttachmentFiles/add(FileName='${normalizedFileName}')`
+      `/items(${itemId})/AttachmentFiles/add(FileName='${safeFileName}')`
     );
 
     const body = fileContent instanceof Blob
@@ -94,10 +95,11 @@ class SharePointService {
       'IF-MATCH': '*',
       'X-HTTP-Method': 'DELETE'
     };
-    const sanitizedName = this.sanitizeFileName(fileName || 'resumo.txt');
+    const sanitizedName = this.sanitizeFileName(fileName || `resumo_${itemId}.txt`);
+    const safeFileName = encodeURIComponent(sanitizedName);
     const url = this.buildUrl(
       listName,
-      `/items(${itemId})/AttachmentFiles/getByFileName('${sanitizedName}')`
+      `/items(${itemId})/AttachmentFiles/getByFileName('${safeFileName}')`
     );
     await this.request(url, { method: 'POST', headers });
     return true;


### PR DESCRIPTION
## Summary
- ensure SharePoint attachment filenames default to per-item names and are sanitized
- encode attachment filenames before calling SharePoint add and delete endpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd6968093c83338cd046ff28a4acc3