### PR TITLE
docs: adicionar documentação detalhada do front CAPEX

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,13 @@
+<!--
+/*! 
+ * index.html
+ * Descrição: Marca a estrutura principal da aplicação CAPEX, incluindo layout, formulários e resumos.
+ * Autor: Matheus Okano
+ * Versão: v1.0
+ * Última atualização: 2025-09-19
+ * Nota: Documentação e comentários adicionados sem alterar a lógica do sistema.
+ */
+-->
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
@@ -9,25 +19,33 @@
 </head>
 <body>
   <!-- =============================================================== -->
-  <!-- Cabeçalho principal com logo e acesso rápido para novo projeto -->
+  <!-- Cabeçalho principal com logo e ação para abertura do formulário -->
+  <!-- Estrutura: botão #newProjectBtn é monitorado pelo JS para abrir o overlay -->
+  <!-- Acessibilidade: header fixo garante visibilidade do CTA; botão recebe foco inicial após carregamento -->
   <!-- =============================================================== -->
   <header class="main-header">
     <div class="logo" aria-label="Logo CAPEX"></div>
+    <!-- Botão primário que dispara a criação de um novo registro de projeto -->
     <button id="newProjectBtn" type="button" class="btn primary">Novo Projeto</button>
   </header>
 
   <!-- =============================================================== -->
-  <!-- Aplicação: sidebar com lista e painel de detalhes do projeto -->
+  <!-- Região principal da aplicação: lista de projetos e painel de detalhes -->
+  <!-- ID #app consumido pelo JS para organizar eventos; layout em grid com aside + section -->
   <!-- =============================================================== -->
   <div id="app" class="app-layout">
+    <!-- Sidebar com filtro de texto e lista dinâmica de projetos carregados do SharePoint -->
     <aside id="projectSidebar" class="sidebar">
       <div class="sidebar-header">
         <h2>Projetos</h2>
+        <!-- Campo de busca para filtrar os cards renderizados na lista via debounce -->
         <input id="projectSearch" type="search" placeholder="Pesquisar por nome" autocomplete="off">
       </div>
+      <!-- Container rolável que recebe os cards via renderProjectList(); role list garante semântica -->
       <div id="projectList" class="project-list" role="list"></div>
     </aside>
 
+    <!-- Painel central com detalhes do projeto selecionado; aria-live notifica mudanças sem recarregar -->
     <section id="projectDetails" class="details" aria-live="polite">
       <div class="empty-state">
         <h2>Selecione um projeto</h2>
@@ -37,14 +55,17 @@
   </div>
 
   <!-- =============================================================== -->
-  <!-- Formulário de criação/edição de projetos CAPEX -->
+  <!-- Overlay de formulário: role=dialog para modal; foco inicial no título para leitores de tela -->
+  <!-- JS controla classe .hidden, tecla ESC e restauração de foco no botão disparador -->
   <!-- =============================================================== -->
   <div id="formOverlay" class="overlay hidden" role="dialog" aria-modal="true" aria-labelledby="formTitle">
+    <!-- Botão de fechar flutuante acessível, usado como fallback de fechamento rápido -->
     <button type="button" class="form-close-btn" aria-label="Fechar">&times;</button>
     <form id="projectForm" class="project-form" novalidate>
       <div class="form-header">
         <h2 id="formTitle">Novo Projeto</h2>
         <div class="form-header-actions">
+          <!-- Botão secundário utilizado para disparar a confirmação de fechamento -->
           <button type="button" id="closeFormBtn" class="btn ghost">Fechar</button>
         </div>
       </div>
@@ -52,13 +73,16 @@
       <input type="hidden" id="statusField" value="Rascunho">
 
       <div class="form-feedback">
+        <!-- Avisos informativos, sucesso ou erro geral do formulário -->
         <div id="formStatus" class="feedback" role="alert" aria-live="polite"></div>
+        <!-- Resumo de validações com aria-live assertive para alertar usuários com tecnologia assistiva -->
         <div id="formErrors" class="feedback" role="alert" aria-live="assertive">
           <strong id="formErrorsTitle" class="feedback-title"></strong>
           <ul id="errorSummaryList" class="error-summary"></ul>
         </div>
       </div>
 
+      <!-- Visualização somente leitura acionada no modo resumo dentro do próprio formulário -->
       <div id="formSummaryView" class="summary-panel form-summary hidden" aria-live="polite">
         <header class="summary-header">
           <h2 id="formSummaryTitle">Resumo do Projeto</h2>
@@ -67,6 +91,7 @@
 
         <div class="summary-body">
           <div id="formSummarySections" class="summary-sections"></div>
+          <!-- Seção condicional para exibir o Gantt dentro do resumo interno -->
           <section id="formSummaryGanttSection" class="summary-section summary-gantt hidden">
             <h3>Gráfico Gantt</h3>
             <div id="formSummaryGanttChart" class="gantt-chart"></div>
@@ -74,6 +99,7 @@
         </div>
 
         <footer class="summary-actions">
+          <!-- Botão para fechar o modo resumo e retornar à edição -->
           <button type="button" id="formSummaryCloseBtn" class="btn secondary">Fechar</button>
         </footer>
       </div>
@@ -81,23 +107,28 @@
       <!-- ============================== -->
       <!-- 1. Sobre o Projeto             -->
       <!-- ============================== -->
+      <!-- Seção sempre visível, agrupa campos essenciais do cadastro -->
       <fieldset class="form-section">
         <legend>1. Sobre o Projeto</legend>
         <div class="field-group">
           <label for="projectName">Nome do Projeto</label>
+          <!-- Campo obrigatório que alimenta o título em cards e resumos -->
           <input id="projectName" name="projectName" type="text" required maxlength="255" placeholder="Título do projeto">
         </div>
         <div class="field-group">
           <label for="projectBudget">Orçamento do Projeto em R$</label>
+          <!-- Valor usado para definir nível de investimento e habilitar seções PEP/Key Projects -->
           <input id="projectBudget" name="projectBudget" type="number" min="0" step="0.01" required>
         </div>
         <div class="field-grid">
           <div class="field-group">
             <label for="approvalYear">Ano de Aprovação</label>
+            <!-- Preenchido automaticamente com o ano corrente e bloqueado para edição manual -->
             <input id="approvalYear" name="approvalYear" type="number" min="1900" max="9999" required readonly>
           </div>
           <div class="field-group">
             <label for="investmentLevel">Nível de Investimento</label>
+            <!-- Seleção calculada via script conforme orçamento convertido em USD -->
             <select id="investmentLevel" name="investmentLevel" required>
               <option value="">Selecione o nível de investimento</option>
               <option value="N1">N1 ≥ $150m Board of Directors</option>
@@ -108,6 +139,7 @@
           </div>
           <div class="field-group">
             <label for="startDate">Data de Início</label>
+            <!-- Datas alimentam validação cruzada com atividades e cronograma Gantt -->
             <input id="startDate" name="startDate" type="date" required>
           </div>
           <div class="field-group">
@@ -120,6 +152,7 @@
       <!-- ============================== -->
       <!-- 2. Origem e Função             -->
       <!-- ============================== -->
+      <!-- Bloco para classificar fonte de recursos e finalidade do investimento -->
       <fieldset class="form-section">
         <legend>2. Origem e Função</legend>
         <div class="field-grid">
@@ -137,6 +170,7 @@
       <!-- ============================== -->
       <!-- 3. Informação Operacional      -->
       <!-- ============================== -->
+      <!-- Seletores encadeados: opções atualizadas via JS com base na empresa escolhida -->
       <fieldset class="form-section">
         <legend>3. Informação Operacional</legend>
         <div class="field-grid">
@@ -225,6 +259,7 @@
       <!-- ============================== -->
       <!-- 4. Detalhamento Complementar   -->
       <!-- ============================== -->
+      <!-- Campos de texto livre para contexto estratégico e solução proposta -->
       <fieldset class="form-section">
         <legend>4. Detalhamento Complementar</legend>
         <div class="field-group">
@@ -240,16 +275,19 @@
       <!-- ============================== -->
       <!-- 5. Elemento PEP (até 1MM)      -->
       <!-- ============================== -->
+      <!-- Exibido somente quando orçamento < 1MM; lista dinâmica clonada via template #simplePepTemplate -->
       <fieldset id="simplePepSection" class="form-section hidden">
         <legend>5. Elemento PEP</legend>
         <p class="hint">Disponível apenas quando o orçamento é inferior a R$ 1.000.000,00.</p>
         <div id="simplePepList" class="dynamic-list"></div>
+        <!-- Botão que adiciona nova linha PEP por meio do template dinamicamente -->
         <button type="button" id="addSimplePepBtn" class="btn ghost">Adicionar PEP</button>
       </fieldset>
 
       <!-- ============================== -->
       <!-- 6. Indicadores de Desempenho   -->
       <!-- ============================== -->
+      <!-- Dados de KPI alimentam o resumo e processos de aprovação -->
       <fieldset class="form-section">
         <legend>6. Indicadores de Desempenho</legend>
         <div class="field-grid">
@@ -283,26 +321,36 @@
       <!-- ============================== -->
       <!-- 7. Key Projects (a partir 1MM) -->
       <!-- ============================== -->
+      <!-- Seção exclusiva para orçamentos >= 1MM com marcos e atividades vinculadas ao Gantt -->
       <fieldset id="keyProjectSection" class="form-section hidden">
         <legend>7. KEY Projects</legend>
         <p class="hint">Disponível quando o orçamento é igual ou superior a R$ 1.000.000,00.</p>
         <div id="milestoneList" class="dynamic-list"></div>
+        <!-- CTA para duplicar o template #milestoneTemplate criando novo marco -->
         <button type="button" id="addMilestoneBtn" class="btn ghost">Adicionar Marco</button>
+        <!-- Container exibido após preencher marcos/atividades; aria-live informa atualizações do Gantt -->
         <div id="ganttContainer" class="gantt-container hidden" aria-live="polite">
           <h3 id="ganttChartTitle">Cronograma do Projeto</h3>
           <div id="ganttChart" class="gantt-chart" role="img" aria-label="Gráfico de Gantt do projeto"></div>
         </div>
       </fieldset>
 
+      <!-- Dicas dinâmicas atualizadas pelo JS conforme validações de orçamento e datas -->
       <p id="budgetHint" class="hint" aria-live="polite"></p>
       <p id="dateHint" class="hint" aria-live="polite"></p>
 
       <div class="form-actions">
+        <!-- Botão principal que dispara fluxo de validação e abre o overlay de resumo -->
         <button type="button" id="saveProjectBtn" class="btn primary">Salvar</button>
       </div>
     </form>
   </div>
 
+  <!-- =============================================================== -->
+  <!-- Overlay de resumo para confirmação antes do envio/ aprovação -->
+  <!-- role=dialog com tabindex=-1 garante foco programático no título -->
+  <!-- Fechamento via botão ou tecla ESC restaurando foco no gatilho -->
+  <!-- =============================================================== -->
   <div
     id="summaryOverlay"
     class="overlay overlay-summary hidden"
@@ -335,6 +383,7 @@
   <!-- =============================================================== -->
   <!-- Templates para listas dinâmicas (PEPs, marcos e atividades)    -->
   <!-- =============================================================== -->
+  <!-- Templates são clonados pelo script e preservam classes/IDs esperados nas validações -->
   <template id="simplePepTemplate">
     <div class="pep-row" data-pep-id="">
       <div class="field-grid three-cols">
@@ -362,6 +411,7 @@
     </div>
   </template>
 
+  <!-- Template para cada marco do Key Project; inclui botão para remover o bloco completo -->
   <template id="milestoneTemplate">
     <div class="milestone" data-milestone-id="">
       <div class="milestone-header">
@@ -378,6 +428,7 @@
     </div>
   </template>
 
+  <!-- Template de atividade dentro de um marco; campos alimentam Gantt e anexos JSON -->
   <template id="activityTemplate">
     <div class="activity" data-activity-id="" data-pep-id="">
       <div class="activity-header">

--- a/style.css
+++ b/style.css
@@ -1,4 +1,24 @@
+/*!
+ * style.css
+ * Descrição: Consolida tokens visuais e estilos de layout para a aplicação CAPEX.
+ * Autor: Matheus Okano
+ * Versão: v1.0
+ * Última atualização: 2025-09-19
+ * Nota: Documentação e comentários adicionados sem alterar a lógica do sistema.
+ */
+
+/* ======================================================================= */
+/* Guia de design                                                          */
+/* ======================================================================= */
+/*
+ * Filosofia: estrutura orientada a tokens de cor, sombras suaves e espaçamento generoso
+ * para reforçar hierarquia visual. Componentes utilizam bordas arredondadas e foco visível
+ * para acessibilidade. Layout principal em grid flexível para suportar monitores amplos e
+ * responsividade até mobile. Tipografia padrão do Microsoft 365 para coerência com SharePoint.
+ */
+
 :root {
+  /* Paleta base e transparências reutilizadas entre botões, cards e overlays */
   --purple: #460a78;
   --violet: #be2846;
   --orange: #f58746;
@@ -50,6 +70,11 @@ p {
 /* ============================================================ */
 /* Botões reutilizáveis                                          */
 /* ============================================================ */
+/*
+ * Define estilos padrão para botões e suas variantes (primary, secondary, ghost, accent, danger).
+ * A transição suave reforça feedback visual imediato. Estados :focus-visible garantem indicador
+ * claro de foco para navegação por teclado, e :disabled bloqueia interação mantendo contraste.
+ */
 .btn {
   border-radius: 12px;
   font-weight: 600;
@@ -151,6 +176,7 @@ p {
   outline-offset: 2px;
 }
 
+/* Ícones padronizados para botões de remover/adicionar em listas dinâmicas */
 .material-symbols-outlined {
   font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
   font-size: 22px;
@@ -161,6 +187,7 @@ p {
 /* Cabeçalho                                                     */
 /* ============================================================ */
 .main-header {
+  /* Cabeçalho fixo mantém acesso constante ao CTA e cria separação visual do conteúdo */
   background: #fff;
   border-bottom: 1px solid var(--border);
   padding: 16px 40px;
@@ -203,6 +230,7 @@ p {
 /* Layout principal                                              */
 /* ============================================================ */
 .app-layout {
+  /* Grid principal organiza sidebar e painel de detalhes com espaçamento generoso */
   display: grid;
   grid-template-columns: 360px 1fr;
   gap: 32px;
@@ -211,6 +239,7 @@ p {
 }
 
 .sidebar {
+  /* Sidebar fixa mantém filtros visíveis durante rolagem do painel central */
   background: var(--card);
   border-radius: 18px;
   border: 1px solid var(--purple-rgba-08);
@@ -255,6 +284,7 @@ p {
 }
 
 .project-list {
+  /* Lista rolável com barra discreta; role=list em HTML auxilia leitores de tela */
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -278,6 +308,7 @@ p {
 }
 
 .project-card {
+  /* Cartão clicável com sombra suave; estado hover reforça affordance */
   background: #fff;
   border-radius: 16px;
   border: 1px solid transparent;
@@ -298,6 +329,7 @@ p {
 }
 
 .project-card.selected {
+  /* Realça card ativo mantendo contraste elevado para indicar seleção atual */
   border-color: var(--purple);
   box-shadow: 0 18px 36px rgba(38, 16, 70, 0.22);
 }
@@ -409,6 +441,7 @@ p {
 }
 
 .project-highlight {
+  /* Caixa de resumo com contraste sutil para valores financeiros e datas */
   background: #f8f9fb;
   border: 1px solid #ececf2;
   border-radius: 16px;
@@ -437,6 +470,7 @@ p {
 }
 
 .project-description {
+  /* Seção textual para contextualização do projeto selecionado */
   display: flex;
   flex-direction: column;
   gap: 18px;
@@ -458,6 +492,7 @@ p {
 }
 
 .project-overview__actions {
+  /* Agrupa botões contextuais (editar, aprovar, visualizar) alinhados à direita */
   display: flex;
   justify-content: flex-end;
   flex-wrap: wrap;
@@ -475,6 +510,7 @@ p {
 /* Formulário                                                    */
 /* ============================================================ */
 .overlay {
+  /* Layer modal cobre toda a viewport e permite rolagem interna controlada */
   position: fixed;
   inset: 0;
   background: rgba(20, 20, 35, 0.55);
@@ -524,6 +560,7 @@ p {
 }
 
 .project-form {
+  /* Estrutura do formulário principal; espaçamento interno mantém legibilidade dos fieldsets */
   background: #fff;
   border-radius: 20px;
   max-width: 1024px;
@@ -566,6 +603,7 @@ p {
 }
 
 .project-form--readonly {
+  /* Quando em modo leitura, remove seções editáveis mantendo apenas resumo */
   padding: 32px 36px;
   gap: 0;
 }
@@ -584,6 +622,7 @@ p {
 }
 
 .overlay-summary {
+  /* Overlay secundário para revisão final; z-index maior evita sobreposição com formulário */
   align-items: center;
   z-index: 20;
 }
@@ -665,6 +704,7 @@ p {
 }
 
 .summary-section {
+  /* Agrupador do resumo final; borda clara para diferenciar blocos temáticos */
   border: 1px solid var(--border);
   border-radius: 16px;
   padding: 20px 24px;
@@ -716,6 +756,7 @@ p {
 }
 
 .summary-table {
+  /* Tabela utilizada para consolidar dados de PEPs; mantém bordas visíveis para leitura */
   width: 100%;
   border-collapse: collapse;
   font-size: 14px;
@@ -735,6 +776,7 @@ p {
 }
 
 .summary-milestones {
+  /* Lista hierárquica de marcos exibidos apenas quando Key Projects está habilitado */
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -831,6 +873,7 @@ p {
 }
 
 .form-section {
+  /* Fieldsets com borda neutra organizam etapas e mantêm consistência visual */
   border: 1px solid var(--border);
   border-radius: 16px;
   padding: 20px 24px;
@@ -845,6 +888,7 @@ p {
 }
 
 .field-group {
+  /* Agrupa label e controle garantindo alinhamento vertical uniforme */
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -858,6 +902,7 @@ p {
 .field-group input,
 .field-group select,
 .field-group textarea {
+  /* Controles com raio suave; foco roxo proporciona feedback visível para teclado */
   border: 1px solid var(--border);
   border-radius: 10px;
   padding: 10px 12px;
@@ -908,6 +953,7 @@ p {
 }
 
 .feedback {
+  /* Área de mensagens do formulário; visibilidade controlada via classe .show */
   border-radius: 12px;
   padding: 12px 16px;
   display: none;
@@ -921,24 +967,28 @@ p {
 }
 
 .feedback--info {
+  /* Tons frios para mensagens informativas ou estados intermediários */
   background: var(--purple-rgba-08);
   color: var(--purple);
   border-color: var(--purple-rgba-15);
 }
 
 .feedback--success {
+  /* Verde suave comunica sucesso mantendo contraste com texto */
   background: #e6f4ea;
   color: #1b5e20;
   border-color: #b7dfb9;
 }
 
 .feedback--warning {
+  /* Amarelo sinaliza atenção sem sugerir erro crítico */
   background: #fff8e1;
   color: #a15c0c;
   border-color: #ffe0a3;
 }
 
 .feedback--error {
+  /* Vermelho de alto contraste destaca falhas de validação */
   background: #fdecea;
   color: #c62828;
   border-color: #f4b4b4;
@@ -964,6 +1014,7 @@ p {
 }
 
 .error-summary ul {
+  /* Sublista exibida quando um grupo de erros reúne múltiplos detalhes */
   margin: 6px 0 0;
   padding-left: 18px;
   list-style: disc;
@@ -1001,10 +1052,12 @@ p {
 }
 
 .field-group.has-error label {
+  /* Label em vermelho reforça associação com aria-invalid aplicado via JS */
   color: #c62828;
 }
 
 .field-group.has-error .field-control {
+  /* Wrapper garante posicionamento correto das mensagens auxiliares */
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -1043,6 +1096,7 @@ p {
 }
 
 .field-error::before {
+  /* Ícone textual comunica erro também para leitores sem suporte a cor */
   content: '⚠️';
 }
 
@@ -1119,6 +1173,7 @@ p {
 }
 
 .gantt-container {
+  /* Moldura do gráfico Gantt exibida quando há atividades válidas */
   margin-top: 12px;
   padding: 18px;
   border-radius: 14px;
@@ -1135,6 +1190,7 @@ p {
 }
 
 .gantt-chart {
+  /* Área onde Google Charts renderiza o Gantt; overflow-x permite navegação em cronogramas longos */
   width: 100%;
   overflow-x: auto;
   border-radius: 8px;
@@ -1148,6 +1204,7 @@ p {
 }
 
 @media (max-width: 1080px) {
+  /* Ajustes para telas intermediárias: sidebar deixa de ser fixa e layout vira coluna única */
   .app-layout {
     grid-template-columns: 1fr;
   }
@@ -1159,6 +1216,7 @@ p {
 }
 
 @media (max-width: 768px) {
+  /* Mobile: reduz padding geral e reorganiza header e grids em coluna única */
   .main-header {
     flex-direction: column;
     align-items: flex-start;


### PR DESCRIPTION
## Resumo
- adicionar cabeçalhos de documentação e comentários estruturais no HTML da aplicação CAPEX
- documentar tokens de design e estados de componentes no CSS mantendo estilos originais
- incorporar JSDoc abrangente, typedefs de domínio e comentários operacionais no script de integração com SharePoint

## Testes
- não executado (somente documentação)

------
https://chatgpt.com/codex/tasks/task_e_68cd968bbcb48333aaf713f02ada98da