### PR TITLE
Avoid adding simple PEP rows when Key Projects is active

### DIFF
--- a/script.js
+++ b/script.js
@@ -3579,6 +3579,13 @@ function updateSimplePepYears() {
  * Garante ao menos uma linha de PEP simples pronta para preenchimento.
  */
 function ensureSimplePepRow() {
+  if (!simplePepList) return;
+  if (simplePepSection?.classList?.contains('hidden')) {
+    return;
+  }
+  if (keyProjectSection && !keyProjectSection.classList.contains('hidden')) {
+    return;
+  }
   const row = createSimplePepRow({ year: parseInt(approvalYearInput.value, 10) || '' });
   simplePepList.append(row);
 }


### PR DESCRIPTION
## Summary
- prevent ensureSimplePepRow from running while the Key Projects section is visible
- stop hidden simple PEP rows from being injected during approval flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdb7f13fd88333af39eb14d7bfad65