### PR TITLE
Avoid creating milestone block in preserve mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -2613,7 +2613,7 @@ function updateBudgetSections(options = {}) {
     if (!preserve) {
       simplePepList.innerHTML = '';
     }
-    if (!milestoneList.children.length) {
+    if (!milestoneList.children.length && !preserve) {
       ensureMilestoneBlock();
     }
   } else {


### PR DESCRIPTION
## Summary
- prevent updateBudgetSections from appending a placeholder milestone when preserving existing data
- ensure editing an existing key project no longer receives an extra blank milestone during approval validation

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cdd95664a08333aba357888f177198