### PR TITLE
Fix activity PEP filtering for SharePoint data

### DIFF
--- a/script.js
+++ b/script.js
@@ -1881,7 +1881,10 @@ function fillFormWithProject(detail) {
       });
       const relatedActivities = activities.filter((act) => act.milestonesIdId === milestone.Id);
       relatedActivities.forEach((activity) => {
-        const relatedPeps = activityPeps.filter((pep) => pep.activitiesId === activity.Id);
+        const actId = Number(activity.Id);
+        const relatedPeps = activityPeps.filter(
+          (pep) => Number(pep.activitiesIdId ?? pep.activitiesId) === actId
+        );
         const primaryPep = relatedPeps[0] || null;
         const activityBlock = addActivityBlock(block, {
           id: activity.Id,


### PR DESCRIPTION
## Summary
- update project form prefill to match activity PEPs using either `activitiesIdId` or legacy `activitiesId`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cde97453f48333904767277b242d77