### PR TITLE
Preserve legacy depreciation cost centers when editing

### DIFF
--- a/script.js
+++ b/script.js
@@ -2797,6 +2797,26 @@ function updateCompanyDependentFields(companyValue, selectedValues) {
     ? rules.depreciation.map((item) => String(item))
     : [];
   populateSelectOptions(depreciationSelect, depreciation, preserve.depreciation);
+
+  const preservedDepreciation = typeof preserve.depreciation === 'string'
+    ? preserve.depreciation.trim()
+    : preserve.depreciation;
+
+  if (
+    depreciationSelect &&
+    depreciationSelect.tagName === 'SELECT' &&
+    preservedDepreciation &&
+    !depreciation.some((item) => (
+      typeof item === 'string' ? item.trim() : item
+    ) === preservedDepreciation)
+  ) {
+    const legacyOption = document.createElement('option');
+    legacyOption.value = preserve.depreciation;
+    legacyOption.textContent = preserve.depreciation;
+    legacyOption.dataset.legacy = 'true';
+    depreciationSelect.appendChild(legacyOption);
+    depreciationSelect.value = preserve.depreciation;
+  }
 }
 
 function isValidSelection({ company, center, location, unit }) {


### PR DESCRIPTION
## Summary
- keep the saved depreciation cost center selected when the option is missing from the allowed list
- add a legacy option dynamically so existing projects keep their value visible while editing

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf09c75e348333a2e910bda575a0a3