### PR TITLE
Atualiza exibição do orçamento restante nas seções de PEP

### DIFF
--- a/script.js
+++ b/script.js
@@ -4426,29 +4426,23 @@ function calculatePepTotal() {
 }
 
 /**
- * Garante existência do elemento que exibe saldo restante dentro de um container.
- * @param {HTMLElement|null} container - Elemento pai que receberá a mensagem.
- * @param {HTMLElement|null} [reference=null] - Nó de referência para inserção antes.
+ * Garante a existência do indicador de orçamento restante junto ao título da seção.
+ * @param {HTMLLegendElement|null} legend - Legenda onde o indicador será inserido.
  * @returns {HTMLElement|null} Elemento criado ou reutilizado.
  */
-function ensurePepRemainingElement(container, reference = null) {
-  if (!container) {
+function ensurePepRemainingElement(legend) {
+  if (!legend) {
     return null;
   }
 
-  let indicator = container.querySelector('.pep-remaining');
+  let indicator = legend.querySelector('.pep-remaining');
   if (indicator) {
     return indicator;
   }
 
-  indicator = document.createElement('div');
+  indicator = document.createElement('span');
   indicator.className = 'pep-remaining';
-
-  if (reference && reference.parentNode === container) {
-    container.insertBefore(indicator, reference);
-  } else {
-    container.appendChild(indicator);
-  }
+  legend.appendChild(indicator);
 
   return indicator;
 }
@@ -4462,25 +4456,36 @@ function updatePepRemainingDisplays({ budget = getProjectBudgetValue(), total = 
   const remainingValue = hasBudget ? budget - total : 0;
   const formattedRemaining = BRL.format(Math.round(remainingValue * 100) / 100);
 
-  if (simplePepList) {
-    simplePepList.querySelectorAll('.pep-row').forEach((row) => {
-      const removeBtn = row.querySelector('.remove-row');
-      const indicator = ensurePepRemainingElement(row, removeBtn);
-      if (indicator) {
-        indicator.textContent = `Orçamento restante: ${formattedRemaining}`;
-      }
-    });
+  const legends = [];
+
+  if (simplePepSection) {
+    const legend = simplePepSection.querySelector('legend');
+    if (legend) {
+      legends.push(legend);
+    }
   }
 
-  if (milestoneList) {
-    milestoneList.querySelectorAll('.activity').forEach((activity) => {
-      const pepFieldGroup = activity.querySelector('.activity-pep-title')?.closest('.field-group');
-      const indicator = ensurePepRemainingElement(pepFieldGroup || activity);
-      if (indicator) {
-        indicator.textContent = `Orçamento restante: ${formattedRemaining}`;
-      }
-    });
+  if (keyProjectSection) {
+    const legend = keyProjectSection.querySelector('legend');
+    if (legend) {
+      legends.push(legend);
+    }
   }
+
+  legends.forEach((legend) => {
+    if (!hasBudget) {
+      const existing = legend.querySelector('.pep-remaining');
+      if (existing) {
+        existing.remove();
+      }
+      return;
+    }
+
+    const indicator = ensurePepRemainingElement(legend);
+    if (indicator) {
+      indicator.textContent = `Orçamento restante: ${formattedRemaining}`;
+    }
+  });
 }
 
 /**

--- a/style.css
+++ b/style.css
@@ -1176,6 +1176,13 @@ p {
   gap: 16px;
 }
 
+.pep-remaining {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--muted);
+  margin-left: 12px;
+}
+
 .pep-row,
 .activity,
 .milestone {


### PR DESCRIPTION
## Summary
- reposiciona o indicador de orçamento restante para junto dos títulos das seções de PEP simples e key projects
- mantém o valor calculado via orçamento do projeto e total de PEPs usando BRL.format
- adiciona estilo dedicado ao novo indicador exibido nos legends

## Testing
- Not run (não aplicável)

------
https://chatgpt.com/codex/tasks/task_e_68d15f0290c883339401cb58da1f465b