### PR TITLE
Adjust sidebar scrolling and card sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -265,6 +265,7 @@ p {
   flex-direction: column;
   align-items: stretch;
   gap: 12px;
+  flex: 0 0 auto;
 }
 
 .sidebar-header h2 {
@@ -296,13 +297,15 @@ p {
   flex-direction: column;
   gap: 12px;
   overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
   padding-right: 6px;
   scrollbar-width: thin;
   scrollbar-color: var(--purple-rgba-20) transparent;
 }
 
 .project-list::-webkit-scrollbar {
-  width: 4px;
+  width: 6px;
 }
 
 .project-list::-webkit-scrollbar-track {
@@ -326,7 +329,8 @@ p {
   display: flex;
   align-items: center;
   gap: 16px;
-  min-height: 65px;
+  min-height: 72px;
+  flex-shrink: 0;
 }
 
 .project-card:hover {


### PR DESCRIPTION
## Summary
- ensure the sidebar header stays fixed while the project list flexes and scrolls independently
- prevent project cards from shrinking by raising their minimum height and disabling flex shrink
- widen the custom scrollbar for easier interaction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d17b162bf883338bb985d0db67d9ac