### PR TITLE
Normaliza validação da data inicial do projeto

### DIFF
--- a/script.js
+++ b/script.js
@@ -4624,6 +4624,15 @@ function parseDateInputValue(value) {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+function normalizeDateOnly(dateLike) {
+  const date = dateLike instanceof Date ? new Date(dateLike.getTime()) : new Date(dateLike);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
 function getDateRangePairs() {
   const pairs = [];
 
@@ -4787,13 +4796,10 @@ function validateProjectStartDateMinimum(options = {}) {
     return true;
   }
 
-  const normalizedStart = new Date(startDate);
-  normalizedStart.setHours(0, 0, 0, 0);
+  const normalizedStart = normalizeDateOnly(startDate);
+  const today = normalizeDateOnly(new Date());
 
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
-  if (normalizedStart < today) {
+  if (normalizedStart && today && normalizedStart < today) {
     projectStartDateInput.setCustomValidity(PROJECT_START_MIN_ERROR_MESSAGE);
     updateProjectDateWarning(PROJECT_START_MIN_ERROR_MESSAGE);
     if (report && typeof projectStartDateInput.reportValidity === 'function') {


### PR DESCRIPTION
## Summary
- adiciona helper normalizeDateOnly para padronizar datas sem horário
- atualiza a validação da data inicial do projeto para comparar somente as partes de data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d17bf589348333a7277f7a3897de87