### PR TITLE
Refactor unit resolution to avoid person multi filters

### DIFF
--- a/script.js
+++ b/script.js
@@ -2565,35 +2565,131 @@ function extractUnitMetadata(groupItems) {
  * @returns {Promise<{units:string[], hasLookup:boolean, hasText:boolean}>} Resultado consolidado.
  */
 async function resolveUserUnits(service, currentUser) {
-  if (!currentUser?.id && !currentUser?.login && !currentUser?.email) {
-    return { units: [], hasLookup: false, hasText: false };
+  const emptyResult = { units: [], hasLookup: false, hasText: false };
+
+  if (!service || typeof service.getItems !== 'function') {
+    console.warn('Serviço SharePoint inválido ao tentar resolver unidades do usuário.');
+    return emptyResult;
   }
 
-  const memberFilters = [];
-  if (currentUser.id) {
-    memberFilters.push(`members/Id eq ${currentUser.id}`);
-  }
-  if (currentUser.login) {
-    memberFilters.push(`members/LoginName eq '${sanitizeForOData(currentUser.login)}'`);
-  }
-  if (currentUser.email) {
-    memberFilters.push(`members/EMail eq '${sanitizeForOData(currentUser.email)}'`);
+  if (!currentUser || (!currentUser.id && !currentUser.login && !currentUser.email)) {
+    return emptyResult;
   }
 
-  const filterExpression = memberFilters.join(' or ');
+  const targetIds = new Set();
+  const targetLogins = new Set();
+  const targetEmails = new Set();
 
+  const normalizedId = Number(currentUser.id);
+  if (!Number.isNaN(normalizedId)) {
+    targetIds.add(normalizedId);
+  }
+
+  if (typeof currentUser.login === 'string') {
+    const trimmedLogin = currentUser.login.trim();
+    if (trimmedLogin) {
+      targetLogins.add(trimmedLogin.toLowerCase());
+    }
+  }
+
+  if (typeof currentUser.email === 'string') {
+    const trimmedEmail = currentUser.email.trim();
+    if (trimmedEmail) {
+      targetEmails.add(trimmedEmail.toLowerCase());
+    }
+  }
+
+  if (!targetIds.size && !targetLogins.size && !targetEmails.size) {
+    return emptyResult;
+  }
+
+  let unitGroups;
   try {
-    const unitGroups = await service.getItems(UNIT_GROUPS_LIST_NAME, {
-      select: 'Id,unit,unit/Id,unit/Title,members/Id,members/LoginName,members/EMail',
+    unitGroups = await service.getItems(UNIT_GROUPS_LIST_NAME, {
+      select: 'Id,Title,unit,unit/Id,unit/Title,members/Id,members/LoginName,members/EMail',
       expand: 'unit,members',
-      filter: filterExpression,
       top: 5000
     });
-    return extractUnitMetadata(unitGroups);
   } catch (error) {
     console.warn('Não foi possível carregar unidades do usuário na lista UnitGroups.', error);
-    return { units: [], hasLookup: false, hasText: false };
+    return emptyResult;
   }
+
+  if (!Array.isArray(unitGroups) || unitGroups.length === 0) {
+    return emptyResult;
+  }
+
+  const itemsWithAccess = [];
+
+  const normalizeMembers = (members) => {
+    if (!members) {
+      return [];
+    }
+
+    if (Array.isArray(members)) {
+      return members.filter(Boolean);
+    }
+
+    if (Array.isArray(members.results)) {
+      return members.results.filter(Boolean);
+    }
+
+    if (typeof members === 'object') {
+      return [members];
+    }
+
+    return [];
+  };
+
+  const matchesCurrentUser = (member) => {
+    if (!member) {
+      return false;
+    }
+
+    if (targetIds.size && member.Id !== undefined && member.Id !== null) {
+      const memberId = Number(member.Id);
+      if (!Number.isNaN(memberId) && targetIds.has(memberId)) {
+        return true;
+      }
+    }
+
+    if (targetLogins.size && member.LoginName) {
+      const loginNormalized = String(member.LoginName).trim().toLowerCase();
+      if (loginNormalized && targetLogins.has(loginNormalized)) {
+        return true;
+      }
+    }
+
+    const memberEmail = member.EMail || member.Email || member.Mail;
+    if (targetEmails.size && memberEmail) {
+      const emailNormalized = String(memberEmail).trim().toLowerCase();
+      if (emailNormalized && targetEmails.has(emailNormalized)) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  for (let index = 0; index < unitGroups.length; index += 1) {
+    const item = unitGroups[index];
+    const members = normalizeMembers(item?.members);
+
+    if (!members.length) {
+      continue;
+    }
+
+    const hasAccess = members.some(matchesCurrentUser);
+    if (hasAccess) {
+      itemsWithAccess.push(item);
+    }
+  }
+
+  if (!itemsWithAccess.length) {
+    return emptyResult;
+  }
+
+  return extractUnitMetadata(itemsWithAccess);
 }
 
 /**


### PR DESCRIPTION
## Summary
- refactor resolveUserUnits to retrieve all UnitGroups entries without OData filters
- perform client-side matching against current user identifiers to support person multi fields
- reuse existing unit metadata extraction to return unique units with lookup/text flags

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e6b390324c8333b6718f7ca141beae