### PR TITLE
Adjust ROCE classification threshold and percentage formatting

### DIFF
--- a/script.js
+++ b/script.js
@@ -4203,8 +4203,8 @@ function formatRocePercentage(value) {
   }
   return value.toLocaleString('pt-BR', {
     style: 'percent',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0
   });
 }
 
@@ -4716,7 +4716,7 @@ function computeRoceMetrics({ gain, loss, budget } = {}) {
   }
 
   const value = (safeGain - safeLoss) / budgetValue;
-  const classification = value > 0.1 ? 'Estratégico' : 'Regular';
+  const classification = value >= 0.1 ? 'Estratégico' : 'Regular';
 
   return {
     gain: safeGain,


### PR DESCRIPTION
## Summary
- classify ROCE values of 10% or higher as "Estratégico"
- present ROCE percentages without decimal places in the UI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee5473d6e48333a6c246f671d3e1c2